### PR TITLE
[FEAT]: Add timestamp to player

### DIFF
--- a/dojo/src/constants.cairo
+++ b/dojo/src/constants.cairo
@@ -30,3 +30,6 @@ pub const NEXT_LEVEL_EXPERIENCE: u8 = 20;
 pub fn ZERO_ADDRESS() -> ContractAddress {
     contract_address_const::<0x0>()
 }
+
+// Seconds per day
+pub const SECONDS_PER_DAY: u64 = 86400;

--- a/dojo/src/helpers/timestamp.cairo
+++ b/dojo/src/helpers/timestamp.cairo
@@ -1,0 +1,13 @@
+// Core imports
+use core::traits::TryInto;
+
+// Constants imports
+use tamagotchi::constants;
+
+#[generate_trait]
+pub impl Timestamp of TimestampTrait {
+    #[inline(always)]
+    fn unix_timestamp_to_day(timestamp: u64) -> u32 {
+        (timestamp / constants::SECONDS_PER_DAY).try_into().unwrap()
+    }
+}

--- a/dojo/src/lib.cairo
+++ b/dojo/src/lib.cairo
@@ -1,6 +1,10 @@
 pub mod constants;
 pub mod store;
 
+pub mod helpers {
+    pub mod timestamp;
+};
+
 pub mod systems {
     pub mod actions;
 }

--- a/dojo/src/lib.cairo
+++ b/dojo/src/lib.cairo
@@ -3,7 +3,7 @@ pub mod store;
 
 pub mod helpers {
     pub mod timestamp;
-};
+}
 
 pub mod systems {
     pub mod actions;

--- a/dojo/src/models/player.cairo
+++ b/dojo/src/models/player.cairo
@@ -26,19 +26,16 @@ pub impl PlayerImpl of PlayerTrait {
     fn update_daily_streak(ref self: Player, current_timestamp: u64) {
         let current_day: u32 = Timestamp::unix_timestamp_to_day(current_timestamp);
 
-        // Don't update if it's the same day
         if current_day == self.last_active_day {
             return;
         }
 
-        // Check if player was active yesterday
         if current_day == self.last_active_day + 1 {
             self.daily_streak += 1;
         } else {
             self.daily_streak = 0;
         }
 
-        // [Effect] Update the last active day
         self.last_active_day = current_day;
     }
 

--- a/dojo/src/models/player.cairo
+++ b/dojo/src/models/player.cairo
@@ -5,16 +5,45 @@ use core::num::traits::zero::Zero;
 // Constants imports
 use tamagotchi::constants;
 
+// Helpers import
+use tamagotchi::helpers::timestamp::Timestamp;
+
 // Model
 #[derive(Copy, Drop, Serde, IntrospectPacked, Debug)]
 #[dojo::model]
 pub struct Player {
     #[key]
     pub address: ContractAddress, 
-    pub current_beast_id: u16
+    pub current_beast_id: u16,
+    pub daily_streak: u16,
+    pub last_active_day: u32,
+    pub creation_day: u32
 }
 
 // Traits Implementations
+#[generate_trait]
+pub impl PlayerImpl of PlayerTrait { 
+    fn update_daily_streak(ref self: Player, current_timestamp: u64) {
+        let current_day: u32 = Timestamp::unix_timestamp_to_day(current_timestamp);
+
+        // Don't update if it's the same day
+        if current_day == self.last_active_day {
+            return;
+        }
+
+        // Check if player was active yesterday
+        if current_day == self.last_active_day + 1 {
+            self.daily_streak += 1;
+        } else {
+            self.daily_streak = 0;
+        }
+
+        // [Effect] Update the last active day
+        self.last_active_day = current_day;
+    }
+
+}
+
 #[generate_trait]
 pub impl PlayerAssert of AssertTrait {
     #[inline(always)]
@@ -33,7 +62,10 @@ pub impl ZeroablePlayerTrait of Zero<Player> {
     fn zero() -> Player {
         Player {
             address: constants::ZERO_ADDRESS(),
-            current_beast_id: 0
+            current_beast_id: 0,
+            daily_streak: 0,
+            last_active_day: 0,
+            creation_day: 1,
         }
     }
 
@@ -65,6 +97,9 @@ mod tests {
         let player = Player {
             address: mock_address,
             current_beast_id: initial_beast_id,
+            daily_streak: 0,
+            last_active_day: 0,
+            creation_day: 1,
         };
 
         assert_eq!(
@@ -75,6 +110,21 @@ mod tests {
         assert_eq!(
             player.current_beast_id, 
             initial_beast_id, 
+            "Current beast ID should be 1"
+        );
+        assert_eq!(
+            player.daily_streak, 
+            0, 
+            "Current beast ID should be 1"
+        );
+        assert_eq!(
+            player.last_active_day, 
+            0, 
+            "Current beast ID should be 1"
+        );
+        assert_eq!(
+            player.creation_day, 
+            1, 
             "Current beast ID should be 1"
         );
     }
@@ -99,6 +149,9 @@ mod tests {
         let player = Player {
             address: mock_address,
             current_beast_id: 0,
+            daily_streak: 0,
+            last_active_day: 0,
+            creation_day: 1,
         };
 
         assert_eq!(
@@ -117,11 +170,17 @@ mod tests {
         let player1 = Player {
             address: address1,
             current_beast_id: 1,
+            daily_streak: 0,
+            last_active_day: 0,
+            creation_day: 1,
         };
 
         let player2 = Player {
             address: address2,
             current_beast_id: 2,
+            daily_streak: 0,
+            last_active_day: 0,
+            creation_day: 1,
         };
 
         assert!(

--- a/dojo/src/store.cairo
+++ b/dojo/src/store.cairo
@@ -18,6 +18,9 @@ use tamagotchi::types::clean_status::{CleanStatus};
 // Constants import
 use tamagotchi::constants;
 
+// Helpers import
+use tamagotchi::helpers::timestamp::Timestamp;
+
 // Store struct.
 #[derive(Copy, Drop)]
 pub struct Store {
@@ -76,10 +79,14 @@ pub impl StoreImpl of StoreTrait {
     // --------- New entities ---------
     fn new_player(mut self: Store) {
         let caller = get_caller_address();
+        let current_timestamp = get_block_timestamp();
 
         let new_player = Player {
             address: caller, 
-            current_beast_id: 0
+            current_beast_id: 0,
+            daily_streak: 0,
+            last_active_day: 0,
+            creation_day: Timestamp::unix_timestamp_to_day(current_timestamp)
         };
 
         self.world.write_model(@new_player)

--- a/dojo/src/systems/actions.cairo
+++ b/dojo/src/systems/actions.cairo
@@ -1,17 +1,14 @@
 // Types import
 use tamagotchi::models::beast_status::BeastStatus;
+
+// Starknet import
 use starknet::ContractAddress;
 
 // Interface definition
 #[starknet::interface]
 pub trait IActions<T> {
-    // ------------------------- Init methods -------------------------
-    fn spawn_player(ref self: T);
-    fn spawn_beast(ref self: T, specie: u8, beast_type: u8);
-    fn add_initial_food(ref self: T);
-    fn set_current_beast(ref self: T, beast_id: u16);
-
     // ------------------------- Beast methods -------------------------
+    fn spawn_beast(ref self: T, specie: u8, beast_type: u8);
     fn update_beast(ref self: T);
     fn feed(ref self: T, food_id: u8);
     fn sleep(ref self: T);
@@ -20,7 +17,12 @@ pub trait IActions<T> {
     fn pet(ref self: T);
     fn clean(ref self: T);
     fn revive(ref self: T);
-
+    
+    // ------------------------- Player methods -------------------------
+    fn spawn_player(ref self: T);
+    fn add_initial_food(ref self: T);
+    fn set_current_beast(ref self: T, beast_id: u16);
+    
     // ------------------------- Other methods -------------------------
     fn init_tap_counter(ref self: T);
     fn tap(ref self: T, specie: u8, beast_type: u8);
@@ -63,7 +65,6 @@ pub mod actions {
     // Dojo Imports
     #[allow(unused_imports)]
     use dojo::model::{ModelStorage};
-
     #[allow(unused_imports)]
     use dojo::event::EventStorage;
 
@@ -82,17 +83,7 @@ pub mod actions {
     // Implementation of the interface methods
     #[abi(embed_v0)]
     impl ActionsImpl of IActions<ContractState> {
-        // ------------------------- Init methods -------------------------
-        fn spawn_player(ref self: ContractState) {
-            let mut world = self.world(@"tamagotchi");
-            let store = StoreTrait::new(world);
-
-            store.new_player();
-
-            self.add_initial_food();
-            self.init_tap_counter();
-        }
-        
+        // ------------------------- Beast methods -------------------------
         fn spawn_beast(ref self: ContractState, specie: u8, beast_type: u8) {
             let mut world = self.world(@"tamagotchi");
             let store = StoreTrait::new(world);
@@ -105,25 +96,6 @@ pub mod actions {
             self.beast_counter.write(current_beast_id+1);
         }
 
-        fn add_initial_food(ref self: ContractState) {
-            let mut world = self.world(@"tamagotchi");
-            let store = StoreTrait::new(world);
-
-            store.init_player_food();
-        }
-        
-        fn set_current_beast(ref self: ContractState, beast_id: u16) {
-            let mut world = self.world(@"tamagotchi");
-            let store = StoreTrait::new(world);
-
-            let mut player: Player = store.read_player();
-            player.assert_exists();
-            player.current_beast_id = beast_id;
-
-            store.write_player(@player);
-        }
-
-         // ------------------------- Beast methods -------------------------
          // This method is used to update the beast related data and write it to the world
         fn update_beast(ref self: ContractState) {
             let mut world = self.world(@"tamagotchi");
@@ -136,7 +108,7 @@ pub mod actions {
             // Update beast status and write it to the world
             let beast_id = player.current_beast_id;
             let mut beast_status: BeastStatus = store.read_beast_status(beast_id);
-            beast_status.calculate_timestamp_based_status(current_timestamp);
+            beast_status.calculate_timestamp_based_status(current_timestamp);   
             store.write_beast_status(@beast_status);
             
             // Update beast and write it to the world
@@ -328,6 +300,35 @@ pub mod actions {
             }
         }
 
+        // ------------------------- Player methods -------------------------
+        fn spawn_player(ref self: ContractState) {
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+
+            store.new_player();
+
+            self.add_initial_food();
+            self.init_tap_counter();
+        }
+
+        fn add_initial_food(ref self: ContractState) {
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+
+            store.init_player_food();
+        }
+        
+        fn set_current_beast(ref self: ContractState, beast_id: u16) {
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+
+            let mut player: Player = store.read_player();
+            player.assert_exists();
+            player.current_beast_id = beast_id;
+
+            store.write_player(@player);
+        }
+
         // ------------------------- Other methods -------------------------
         fn init_tap_counter(ref self: ContractState) {
             let mut world = self.world(@"tamagotchi");
@@ -389,7 +390,6 @@ pub mod actions {
             beast_status
         }
 
-        
         fn get_beast_age(ref self: ContractState) -> u16 {
             let mut world = self.world(@"tamagotchi");
             let store = StoreTrait::new(world);

--- a/dojo/src/systems/actions.cairo
+++ b/dojo/src/systems/actions.cairo
@@ -22,6 +22,7 @@ pub trait IActions<T> {
     fn spawn_player(ref self: T);
     fn add_initial_food(ref self: T);
     fn set_current_beast(ref self: T, beast_id: u16);
+    fn update_player_daily_streak(ref self: T);
     
     // ------------------------- Other methods -------------------------
     fn init_tap_counter(ref self: T);
@@ -53,7 +54,7 @@ pub mod actions {
     #[allow(unused_imports)]
     use tamagotchi::models::beast::{Beast, BeastTrait};
     use tamagotchi::models::beast_status::{BeastStatus, BeastStatusTrait};
-    use tamagotchi::models::player::{Player, PlayerAssert};
+    use tamagotchi::models::player::{Player, PlayerAssert, PlayerTrait};
     use tamagotchi::models::food::{Food};
 
     // Constants import
@@ -325,6 +326,20 @@ pub mod actions {
             let mut player: Player = store.read_player();
             player.assert_exists();
             player.current_beast_id = beast_id;
+
+            store.write_player(@player);
+        }
+
+        fn update_player_daily_streak(ref self: ContractState) {
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+
+            let current_timestamp = get_block_timestamp();
+
+            let mut player: Player = store.read_player();
+            player.assert_exists();
+
+            player.update_daily_streak(current_timestamp);
 
             store.write_player(@player);
         }


### PR DESCRIPTION
### **Summary**  
- Closes #231 
- Added a **daily timestamp** to the player model to track **daily streaks** and improve **metrics handling** for Torii-gathered data.  
- Introduced a **new method** in the actions system to update the **daily streak**.  
  - *This method must be called at least once when a player logs in* and can be triggered when the controller connects.  
- Added a **helpers module** with **timestamp-related functions** (more utilities can be added in the future).  
- **Unit tests are not required for now**, as this functionality is primarily for **metrics tracking**.  
