### PR TITLE
[FEAT]: Improve timer to decrease stats

### DIFF
--- a/dojo/src/constants.cairo
+++ b/dojo/src/constants.cairo
@@ -38,3 +38,4 @@ pub const SECONDS_PER_DAY: u64 = 86400;
 
 // Total seconds in 10 minutes
 pub const SECONDS_IN_10_MINUTES: u64 = 600;
+pub const SECONDS_FOR_TESTING: u64 = 30;

--- a/dojo/src/models/beast_status.cairo
+++ b/dojo/src/models/beast_status.cairo
@@ -46,7 +46,7 @@ pub impl BeastStatusImpl of BeastStatusTrait {
 
     fn calculate_timestamp_based_status(ref self: BeastStatus, current_timestamp: u64){
         let total_seconds: u64 =  current_timestamp - self.last_timestamp;
-        let total_points: u64 = total_seconds / constants::SECONDS_IN_10_MINUTES;
+        let total_points: u64 = total_seconds / constants::SECONDS_FOR_TESTING;
 
         if total_points < constants::MAX_POINTS {
             let points_to_drecrease: u8 = total_points.try_into().unwrap();


### PR DESCRIPTION
# Improve timer to decrease stats 🧮

## Overview
Implemented a faster time constant for testing the status decrease mechanics. Changed the value to make testing more efficient without having to wait 10 minutes for each status decrement cycle.

## Changes
- Adjusted time constant: Add SECONDS_FOR_TESTING to 30 seconds for testing purposes