### PR TITLE
[FEAT]: Adjust beast status constants for improved gameplay balance

### DIFF
--- a/dojo/src/constants.cairo
+++ b/dojo/src/constants.cairo
@@ -9,7 +9,7 @@ pub const MAX_HYGIENE: u8 = 100;
 pub const MAX_POINTS: u64 = 100;
 
 // Status values to init a Beast
-pub const MIN_INITIAL_STATUS: u8 = 50;
+pub const MIN_INITIAL_STATUS: u8 = 70;
 pub const MAX_INITIAL_STATUS: u8 = 90;
 
 // Tap counter max value
@@ -23,10 +23,10 @@ pub const MAX_BABY_LEVEL: u8 = 15;
 
 // Increase or decrease values
 pub const XS_UPDATE_POINTS: u8 = 2;
-pub const S_UPDATE_POINTS: u8 = 5;
-pub const M_UPDATE_POINTS: u8 = 8;
-pub const L_UPDATE_POINTS: u8 = 12;
-pub const XL_UPDATE_POINTS: u8 = 15;
+pub const S_UPDATE_POINTS: u8 = 4;
+pub const M_UPDATE_POINTS: u8 = 6;
+pub const L_UPDATE_POINTS: u8 = 8;
+pub const XL_UPDATE_POINTS: u8 = 10;
 
 // Next level experience
 pub const NEXT_LEVEL_EXPERIENCE: u8 = 20;
@@ -40,5 +40,4 @@ pub fn ZERO_ADDRESS() -> ContractAddress {
 pub const SECONDS_PER_DAY: u64 = 86400;
 
 // Total seconds in 10 minutes
-pub const SECONDS_IN_10_MINUTES: u64 = 600;
-pub const SECONDS_FOR_TESTING: u64 = 30;
+pub const SECONDS_FOR_DECREASE: u64 = 220;

--- a/dojo/src/models/beast_status.cairo
+++ b/dojo/src/models/beast_status.cairo
@@ -63,13 +63,13 @@ pub impl BeastStatusImpl of BeastStatusTrait {
 
     fn calculate_timestamp_based_status(ref self: BeastStatus, current_timestamp: u64){
         let total_seconds: u64 =  current_timestamp - self.last_timestamp;
-        let total_points: u64 = total_seconds / constants::SECONDS_FOR_TESTING;
+        let total_points: u64 = total_seconds / constants::SECONDS_FOR_DECREASE;
 
         if total_points < constants::MAX_POINTS {
             let points_to_drecrease: u8 = total_points.try_into().unwrap();
 
-            let multiplied_hunger_to_decrease = points_to_drecrease * 2;
-            let multiplied_energy_to_decrease = points_to_drecrease * 2;
+            let multiplied_hunger_to_decrease = (points_to_drecrease * 3) / 2;
+            let multiplied_energy_to_decrease = (points_to_drecrease * 3) / 2; 
 
             if self.is_alive == true {
                 // Decrease energy based on conditions

--- a/dojo/src/systems/game.cairo
+++ b/dojo/src/systems/game.cairo
@@ -206,8 +206,8 @@ pub mod game {
                 };
 
                 // Decrease hunger safety avoiding overflow
-                beast_status.hunger = if beast_status.hunger >= constants::M_UPDATE_POINTS {
-                    beast_status.hunger - constants::M_UPDATE_POINTS
+                beast_status.hunger = if beast_status.hunger >= constants::S_UPDATE_POINTS {
+                    beast_status.hunger - constants::S_UPDATE_POINTS
                 } else {
                     0
                 };


### PR DESCRIPTION
# Tamagotchi Status System Improvement

## Description
This PR enhances the balance of the Tamagotchi status system by adjusting the decrement timer, increment values, and multipliers to create a more balanced gameplay experience.

## Changes Made

- Replaced `SECONDS_IN_10_MINUTES` (600s) with `SECONDS_FOR_DECREASE` (220s)
- Adjusted the hunger/energy decrement multiplier from 2x to 1.5x
- Modified increment values:
  - `XL_UPDATE_POINTS`: 15 → 10
  - `L_UPDATE_POINTS`: 12 → 8
  - `M_UPDATE_POINTS`: 8 → 6
  - `S_UPDATE_POINTS`: 5 → 4
- Reduced the negative impact of playing on hunger (using `S_UPDATE_POINTS` instead of `M_UPDATE_POINTS`)
- Adjusted random initial values range from 50-90 to 70-90

## Justification

The previous system had decrements every 10 minutes (600s), which was too permissive and reduced player engagement. 

The new system:

- Requires interaction approximately every 25 minutes to maintain high attributes
- Allows the beast to survive 4 hours without attention (vs. 8.3 hours previously)
- Creates a better gameplay rhythm to maintain engagement
- Makes actions have a more significant and lasting impact
- Provides a more consistent initial experience

## Impact on User Experience

- Casual player: Can keep their beast alive with 3-4 sessions per day
- Gameplay session: Needs to feed once in a 30-minute session
- Actions: Each action has a noticeable impact that lasts approx. 25 minutes
- Balance: Better differentiation between food types and actions

## Testing

<img width="674" alt="image" src="https://github.com/user-attachments/assets/60011e00-1ddc-4d32-ab05-6c40e0921a51" />
