### PR TITLE
[REFACTOR]: adjust food amount and update food initialization

### DIFF
--- a/dojo/src/constants.cairo
+++ b/dojo/src/constants.cairo
@@ -16,7 +16,7 @@ pub const MAX_INITIAL_STATUS: u8 = 90;
 pub const MAX_TAP_COUNTER: u8 = 10;
 
 // Max food amount per player
-pub const MAX_FOOD_AMOUNT: u8 = 50;
+pub const MAX_FOOD_AMOUNT: u8 = 5;
 
 // Max level as babybeast
 pub const MAX_BABY_LEVEL: u8 = 15;

--- a/dojo/src/models/beast.cairo
+++ b/dojo/src/models/beast.cairo
@@ -8,8 +8,11 @@ use tamagotchi::types::food::{FoodType};
 // Constants import
 use tamagotchi::constants;
 
+// Helpers
+use tamagotchi::helpers::pseudo_random::PseudoRandom;
+
 //Model
-#[derive(Drop, Serde, IntrospectPacked, Debug)]
+#[derive(Drop, Serde, Copy, IntrospectPacked, Debug)]
 #[dojo::model]
 pub struct Beast {
     #[key]
@@ -32,6 +35,29 @@ pub impl BeastImpl of BeastTrait {
         let total_days: u64 = total_seconds / 86400; // 86400: total seconds in a day
         
         self.age = total_days.try_into().unwrap();
+    }
+
+    fn get_favorite_foods(self: Beast) -> Array<u8> {
+        let beast_type: BeastType = self.beast_type.into();
+        
+        match beast_type {
+            BeastType::Light => {
+                // Cherry (3), Fish (10), Corn (15)
+                array![3, 10, 15]
+            },
+            BeastType::Magic => {
+                // Chicken (8), Apple (1), Cheese (7)
+                array![8, 1, 7]
+            },
+            BeastType::Shadow => {
+                // Beef (13), BlueBerry (12), Potato (16)
+                array![13, 12, 16]
+            },
+            _ => {
+                // By default, use Apple
+                array![1]
+            }
+        }
     }
 
     fn is_favorite_meal(ref self: Beast, food_id: u8) -> bool {
@@ -68,6 +94,31 @@ pub impl BeastImpl of BeastTrait {
         }
     }
 
+    fn get_random_favorite_food(self: Beast, beast_id: u16) -> u8 {
+        let favorites = self.get_favorite_foods();
+        let count: u32 = favorites.len();
+    
+        // Convert count to u8 and subtract 1
+        let max_index: u8 = (count - 1).try_into().unwrap();
+        
+        // Choose a random index
+        let random_index = PseudoRandom::generate_random_u8(beast_id, 1, 0, max_index);
+        
+        // Return the selected favorite food
+        *favorites.at(random_index.into())
+    }
+
+    fn get_random_common_food(self: Beast, beast_id: u16) -> u8 {
+        // Common foods that are not favorites for any type
+        let common_food_ids = array![4, 5, 6, 11, 14]; 
+        
+        // Choose a random index (between 0 and 4)
+        let random_index = PseudoRandom::generate_random_u8(beast_id, 2, 0, 4);
+        
+        // Return the selected common food
+        *common_food_ids.at(random_index.into())
+    }
+
     fn feed(ref self: Beast, food_id: u8) -> (u8, u8, u8) {
         if self.is_favorite_meal(food_id){
             // (hunger, happiness, energy)
@@ -84,6 +135,7 @@ pub impl BeastImpl of BeastTrait {
 #[cfg(test)]
 mod tests {
     use super::Beast;
+    use super::BeastTrait;
     use starknet::contract_address_const;
 
     #[test]
@@ -121,4 +173,137 @@ mod tests {
 
         assert_eq!(beast.beast_id, 1, "Beast ID should be 1");
     }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_get_random_favorite_food() {
+        // Create beast instances for each type
+        let player_address = contract_address_const::<0x123>();
+        
+        // Beast Light (beast_type = 1)
+        let light_beast = Beast {
+            player: player_address,
+            beast_id: 1,
+            age: 1,
+            birth_date: 5000,
+            specie: 1,
+            beast_type: 1, // Light
+        };
+        
+        // Beast Magic (beast_type = 2)
+        let magic_beast = Beast {
+            player: player_address,
+            beast_id: 2,
+            age: 1,
+            birth_date: 5000,
+            specie: 1,
+            beast_type: 2, // Magic
+        };
+        
+        // Beast Shadow (beast_type = 3)
+        let shadow_beast = Beast {
+            player: player_address,
+            beast_id: 3,
+            age: 1,
+            birth_date: 5000,
+            specie: 1,
+            beast_type: 3, // Shadow
+        };
+        
+        // Light beast - should be one of: Cherry (3), Fish (10), Corn (15)
+        let light_food = light_beast.get_random_favorite_food(1);
+        let is_valid_light_favorite = 
+            light_food == 3 || light_food == 10 || light_food == 15;
+        assert(is_valid_light_favorite, 'Invalid Light favorite food');
+        
+        // magic beast - should be one of: Chicken (8), Apple (1), Cheese (7)
+        let magic_food = magic_beast.get_random_favorite_food(2);
+        let is_valid_magic_favorite = 
+            magic_food == 8 || magic_food == 1 || magic_food == 7;
+        assert(is_valid_magic_favorite, 'Invalid Magic favorite food');
+        
+        // Shadow beast - should be one of: Beef (13), BlueBerry (12), Potato (16)
+        let shadow_food = shadow_beast.get_random_favorite_food(3);
+        let is_valid_shadow_favorite = 
+            shadow_food == 13 || shadow_food == 12 || shadow_food == 16;
+        assert(is_valid_shadow_favorite, 'Invalid Shadow favorite food');
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_get_random_common_food() {
+        let player_address = contract_address_const::<0x123>();
+        let mut beast = Beast {
+            player: player_address,
+            beast_id: 1,
+            age: 1,
+            birth_date: 5000,
+            specie: 1,
+            beast_type: 1, // Light
+        };
+        
+        // Get common food
+        let common_food = beast.get_random_common_food(1);
+        
+        // Verify that common food is not favorite
+        let is_favorite = beast.is_favorite_meal(common_food);
+        assert(!is_favorite, 'Food should not be favorite');
+        
+        // Verify that common food is in the predefined list of common foods
+        let is_valid_common = 
+            common_food == 4 || common_food == 5 || common_food == 6 || 
+            common_food == 11 || common_food == 14;
+        assert(is_valid_common, 'Invalid common food');
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_different_beasts_different_foods() {
+        let player_address = contract_address_const::<0x123>();
+        
+        let beast1 = Beast {
+            player: player_address,
+            beast_id: 1,
+            age: 1,
+            birth_date: 5000,
+            specie: 1,
+            beast_type: 1, 
+        };
+        
+        let beast2 = Beast {
+            player: player_address,
+            beast_id: 2, 
+            age: 1,
+            birth_date: 5000,
+            specie: 1,
+            beast_type: 1, 
+        };
+        
+        // The beast_id are different, so they should get different foods
+        let favorite_food1 = beast1.get_random_favorite_food(1);
+        let favorite_food2 = beast2.get_random_favorite_food(2);
+        
+        let common_food1 = beast1.get_random_common_food(1);
+        let common_food2 = beast2.get_random_common_food(2);
+        
+        // Verify that they are valid foods for their type
+        let is_valid_favorite1 = 
+            favorite_food1 == 3 || favorite_food1 == 10 || favorite_food1 == 15;
+        assert(is_valid_favorite1, 'Invalid favorite food 1');
+        
+        let is_valid_favorite2 = 
+            favorite_food2 == 3 || favorite_food2 == 10 || favorite_food2 == 15;
+        assert(is_valid_favorite2, 'Invalid favorite food 2');
+        
+        let is_valid_common1 = 
+            common_food1 == 4 || common_food1 == 5 || common_food1 == 6 || 
+            common_food1 == 11 || common_food1 == 14;
+        assert(is_valid_common1, 'Invalid common food 1');
+        
+        let is_valid_common2 = 
+            common_food2 == 4 || common_food2 == 5 || common_food2 == 6 || 
+            common_food2 == 11 || common_food2 == 14;
+        assert(is_valid_common2, 'Invalid common food 2');
+    }
+
 }

--- a/dojo/src/store.cairo
+++ b/dojo/src/store.cairo
@@ -206,22 +206,18 @@ pub impl StoreImpl of StoreTrait {
     fn init_player_food(mut self: Store) {
         let caller = get_caller_address();
 
-        self.new_apples(caller);
-        self.new_bananas(caller);
-        self.new_cherries(caller);
-        self.new_burguers(caller);
-        self.new_cake_chocolates(caller);
-        self.new_cake_strawberries(caller);
-        self.new_cheeses(caller);
+        // Favorite for magic
         self.new_chickens(caller);
-        self.new_eggs(caller);
+        self.new_apples(caller);
+        // Favorite for light
+        self.new_cherries(caller);
         self.new_fish(caller);
-        self.new_french_fries(caller);
-        self.new_blue_berries(caller);
+        // Favorite for shadow
         self.new_beefs(caller);
-        self.new_pizzas(caller);
-        self.new_corns(caller);
         self.new_potatoes(caller);
+        // Common
+        self.new_bananas(caller);
+        self.new_blue_berries(caller);
     }
 
     fn new_beast_status(mut self: Store, beast_id: u16) {

--- a/dojo/src/store.cairo
+++ b/dojo/src/store.cairo
@@ -6,7 +6,7 @@ use dojo::world::WorldStorage;
 use dojo::model::ModelStorage;
 
 // Models imports
-use tamagotchi::models::beast::{Beast};
+use tamagotchi::models::beast::{Beast, BeastTrait};
 use tamagotchi::models::beast_status::{BeastStatus, BeastStatusTrait};
 use tamagotchi::models::player::{Player};
 use tamagotchi::models::food::{Food};
@@ -91,133 +91,158 @@ pub impl StoreImpl of StoreTrait {
         self.world.write_model(@new_player)
     }
 
-    fn new_apples(mut self: Store, caller: ContractAddress) {
+    fn new_food(mut self: Store, food_id: u8, amount: u8) {
+        let caller = get_caller_address();
+
+        let food_type: FoodType = food_id.into(); // Convert u8 to FoodType
+
+        match food_type {
+            FoodType::Apple => self.new_apples(caller, amount),
+            FoodType::Banana => self.new_bananas(caller, amount),
+            FoodType::Cherry => self.new_cherries(caller, amount),
+            FoodType::Burguer => self.new_burguers(caller, amount),
+            FoodType::CakeChocolate => self.new_cake_chocolates(caller, amount),
+            FoodType::CakeStrawberry => self.new_cake_strawberries(caller, amount),
+            FoodType::Cheese => self.new_cheeses(caller, amount),
+            FoodType::Chicken => self.new_chickens(caller, amount),
+            FoodType::Eggs => self.new_eggs(caller, amount),
+            FoodType::Fish => self.new_fish(caller, amount),
+            FoodType::FrenchFries => self.new_french_fries(caller, amount),
+            FoodType::BlueBerry => self.new_blue_berries(caller, amount),
+            FoodType::Beef => self.new_beefs(caller, amount),
+            FoodType::Pizza => self.new_pizzas(caller, amount),
+            FoodType::Corn => self.new_corns(caller, amount),
+            FoodType::Potato => self.new_potatoes(caller, amount),
+            _ => {}
+        }
+
+    }
+
+    fn new_apples(mut self: Store, caller: ContractAddress, amount: u8) {
         let apples = Food {
-            player: caller, id: FoodType::Apple.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Apple.into(), amount: amount,
         };
         self.world.write_model(@apples);
     }
 
-    fn new_bananas(mut self: Store, caller: ContractAddress) {
+    fn new_bananas(mut self: Store, caller: ContractAddress, amount: u8) {
         let bananas = Food {
-            player: caller, id: FoodType::Banana.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Banana.into(), amount: amount,
         };
         self.world.write_model(@bananas);
     }
 
-    fn new_cherries(mut self: Store, caller: ContractAddress) {
+    fn new_cherries(mut self: Store, caller: ContractAddress, amount: u8) {
         let cherries = Food {
-            player: caller, id: FoodType::Cherry.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Cherry.into(), amount: amount,
         };
         self.world.write_model(@cherries);
     }
 
-    fn new_burguers(mut self: Store, caller: ContractAddress) {
+    fn new_burguers(mut self: Store, caller: ContractAddress, amount: u8) {
         let burguers = Food {
-            player: caller, id: FoodType::Burguer.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Burguer.into(), amount: amount,
         };
         self.world.write_model(@burguers);
     }
 
-    fn new_cake_chocolates(mut self: Store, caller: ContractAddress) {
+    fn new_cake_chocolates(mut self: Store, caller: ContractAddress, amount: u8) {
         let cake_chocolates = Food {
-            player: caller, id: FoodType::CakeChocolate.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::CakeChocolate.into(), amount: amount,
         };
         self.world.write_model(@cake_chocolates);
     }
 
-    fn new_cake_strawberries(mut self: Store, caller: ContractAddress) {
+    fn new_cake_strawberries(mut self: Store, caller: ContractAddress, amount: u8) {
         let cake_strawberries = Food {
-            player: caller, id: FoodType::CakeStrawberry.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::CakeStrawberry.into(), amount: amount,
         };
         self.world.write_model(@cake_strawberries);
     }
 
-    fn new_cheeses(mut self: Store, caller: ContractAddress) {
+    fn new_cheeses(mut self: Store, caller: ContractAddress, amount: u8) {
         let cheeses = Food {
-            player: caller, id: FoodType::Cheese.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Cheese.into(), amount: amount,
         };
         self.world.write_model(@cheeses);
     }
 
-    fn new_chickens(mut self: Store, caller: ContractAddress) {
+    fn new_chickens(mut self: Store, caller: ContractAddress, amount: u8) {
         let chickens = Food {
-            player: caller, id: FoodType::Chicken.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Chicken.into(), amount: amount,
         };
         self.world.write_model(@chickens);
     }
 
-    fn new_eggs(mut self: Store, caller: ContractAddress) {
+    fn new_eggs(mut self: Store, caller: ContractAddress, amount: u8) {
         let eggs = Food {
-            player: caller, id: FoodType::Eggs.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Eggs.into(), amount: amount,
         };
         self.world.write_model(@eggs);
     }
 
-    fn new_fish(mut self: Store, caller: ContractAddress) {
+    fn new_fish(mut self: Store, caller: ContractAddress, amount: u8) {
         let fish = Food {
-            player: caller, id: FoodType::Fish.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Fish.into(), amount: amount,
         };
         self.world.write_model(@fish);
     }
 
-    fn new_french_fries(mut self: Store, caller: ContractAddress) {
+    fn new_french_fries(mut self: Store, caller: ContractAddress, amount: u8) {
         let french_fries = Food {
-            player: caller, id: FoodType::FrenchFries.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::FrenchFries.into(), amount: amount,
         };
         self.world.write_model(@french_fries);
     }
 
-    fn new_blue_berries(mut self: Store, caller: ContractAddress) {
+    fn new_blue_berries(mut self: Store, caller: ContractAddress, amount: u8) {
         let blue_berries = Food {
-            player: caller, id: FoodType::BlueBerry.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::BlueBerry.into(), amount: amount,
         };
         self.world.write_model(@blue_berries);
     }
 
-    fn new_beefs(mut self: Store, caller: ContractAddress) {
+    fn new_beefs(mut self: Store, caller: ContractAddress, amount: u8) {
         let beefs = Food {
-            player: caller, id: FoodType::Beef.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Beef.into(), amount: amount,
         };
         self.world.write_model(@beefs);
     }
 
-    fn new_pizzas(mut self: Store, caller: ContractAddress) {
+    fn new_pizzas(mut self: Store, caller: ContractAddress, amount: u8) {
         let pizzas = Food {
-            player: caller, id: FoodType::Pizza.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Pizza.into(), amount: amount,
         };
         self.world.write_model(@pizzas);
     }
 
-    fn new_corns(mut self: Store, caller: ContractAddress) {
+    fn new_corns(mut self: Store, caller: ContractAddress, amount: u8) {
         let corns = Food {
-            player: caller, id: FoodType::Corn.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Corn.into(), amount: amount,
         };
         self.world.write_model(@corns);
     }
 
-    fn new_potatoes(mut self: Store, caller: ContractAddress) {
+    fn new_potatoes(mut self: Store, caller: ContractAddress, amount: u8) {
         let potatoes = Food {
-            player: caller, id: FoodType::Potato.into(), amount: constants::MAX_FOOD_AMOUNT,
+            player: caller, id: FoodType::Potato.into(), amount: amount,
         };
         self.world.write_model(@potatoes);
     }
 
-    fn init_player_food(mut self: Store) {
-        let caller = get_caller_address();
+    fn init_player_food(mut self: Store, beast_id: u16) {
+        // Read the beast instance
+        let beast = self.read_beast(beast_id);
+    
+        // Get a random favorite food for this beast
+        let favorite_food_id = beast.get_random_favorite_food(beast_id);
 
-        // Favorite for magic
-        self.new_chickens(caller);
-        self.new_apples(caller);
-        // Favorite for light
-        self.new_cherries(caller);
-        self.new_fish(caller);
-        // Favorite for shadow
-        self.new_beefs(caller);
-        self.new_potatoes(caller);
-        // Common
-        self.new_bananas(caller);
-        self.new_blue_berries(caller);
+        // Get a random common food for this beast
+        let common_food_id = beast.get_random_common_food(beast_id);
+    
+        // Create both foods for the player with the initial amount
+        self.new_food(favorite_food_id, constants::MAX_FOOD_AMOUNT);
+        self.new_food(common_food_id, constants::MAX_FOOD_AMOUNT);
     }
 
     fn new_beast_status(mut self: Store, beast_id: u16) {

--- a/dojo/src/systems/player.cairo
+++ b/dojo/src/systems/player.cairo
@@ -3,7 +3,6 @@
 pub trait IPlayer<T> {
     // ------------------------- Player methods -------------------------
     fn spawn_player(ref self: T);
-    fn add_initial_food(ref self: T);
     fn set_current_beast(ref self: T, beast_id: u16);
     fn update_player_daily_streak(ref self: T);
     fn update_player_total_points(ref self: T, points: u32);
@@ -42,15 +41,6 @@ pub mod player {
             let store = StoreTrait::new(world);
 
             store.new_player();
-
-            self.add_initial_food();
-        }
-
-        fn add_initial_food(ref self: ContractState) {
-            let mut world = self.world(@"tamagotchi");
-            let store = StoreTrait::new(world);
-
-            store.init_player_food();
         }
         
         fn set_current_beast(ref self: ContractState, beast_id: u16) {

--- a/dojo/src/systems/player.cairo
+++ b/dojo/src/systems/player.cairo
@@ -3,9 +3,11 @@
 pub trait IPlayer<T> {
     // ------------------------- Player methods -------------------------
     fn spawn_player(ref self: T);
+    fn add_initial_food(ref self: T, beast_id: u16);
     fn set_current_beast(ref self: T, beast_id: u16);
     fn update_player_daily_streak(ref self: T);
     fn update_player_total_points(ref self: T, points: u32);
+    fn add_or_update_food_amount(ref self: T, food_id: u8, amount: u8);
 }
 
 #[dojo::contract]
@@ -20,6 +22,7 @@ pub mod player {
     #[allow(unused_imports)]
     use tamagotchi::models::beast::{Beast, BeastTrait};
     use tamagotchi::models::player::{Player, PlayerAssert, PlayerTrait};
+    use tamagotchi::models::food::{Food, FoodTrait};
 
     // Store import
     use tamagotchi::store::{StoreTrait};
@@ -41,6 +44,13 @@ pub mod player {
             let store = StoreTrait::new(world);
 
             store.new_player();
+        }
+
+        fn add_initial_food(ref self: ContractState, beast_id: u16) {
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+
+            store.init_player_food(beast_id);
         }
         
         fn set_current_beast(ref self: ContractState, beast_id: u16) {
@@ -78,6 +88,24 @@ pub mod player {
             player.update_total_points(points);
 
             store.write_player(@player);
+        }
+
+        fn add_or_update_food_amount(ref self: ContractState, food_id: u8, amount: u8) {
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+        
+            // Read the current food model using the provided ID
+            let mut food: Food = store.read_food(food_id);
+
+            if food.amount == 0 {
+                // If the food does not exist, create a new one
+                store.new_food(food_id, amount);
+            }
+            else {
+                // If the food already exists, update the amount
+                food.update_food_total_amount(amount);
+                store.write_food(@food);
+            }
         }
 
     }

--- a/dojo/src/tests/test_food.cairo
+++ b/dojo/src/tests/test_food.cairo
@@ -10,7 +10,6 @@ mod tests {
     // Import models and types
     use tamagotchi::models::food::{Food};
     use tamagotchi::models::beast_status::{BeastStatus};
-    use tamagotchi::constants;
     use tamagotchi::tests::utils::{
         utils::{
             PLAYER, cheat_caller_address, create_game_system, create_player_system,
@@ -21,36 +20,36 @@ mod tests {
     #[test]
     #[available_gas(60000000)]
     fn test_add_initial_food() {
-        // Initialize test environment]
+        // Initialize test environment
         let world = create_test_world();
         let player_system = create_player_system(world);
+        let game_system = create_game_system(world);
 
         cheat_caller_address(PLAYER());
 
-        // Initialize player and add initial food
+        // Initialize player
         player_system.spawn_player();
-        player_system.add_initial_food();
+        game_system.spawn_beast(1, 1); 
+        player_system.set_current_beast(1);
 
-        // Read foods after initialization using correct IDs (1, 2, 3)
-        let apple: Food = world.read_model((PLAYER(), 1));
-        let banana: Food = world.read_model((PLAYER(), 2));
-        let cherry: Food = world.read_model((PLAYER(), 3));
+        game_system.add_initial_food(1);
 
-        // Debug print
-        // debug::print_felt252('Food name in storage:');
-        // debug::print_felt252(apple.name);
-        // debug::print_felt252(banana.name);
-        // debug::print_felt252(cherry.name);
+        let mut food_count = 0;
+        let mut k: u8 = 1; 
 
-        // Verify food types
-        assert(apple.id == 1, 'wrong apple type');
-        assert(banana.id == 2, 'wrong banana type');
-        assert(cherry.id == 3, 'wrong cherry type');
+        while k <= 16 {
+            let food: Food = world.read_model((PLAYER(), k));
+            
+            if food.amount > 0 {
+                food_count += 1;
+                println!("Found food with ID {} and amount {}", k, food.amount);
+            }
+            
+            k += 1;
+        };
 
-        // Verify initial amounts
-        assert(apple.amount == constants::MAX_FOOD_AMOUNT, 'wrong apple amount');
-        assert(banana.amount == constants::MAX_FOOD_AMOUNT, 'wrong banana amount');
-        assert(cherry.amount == constants::MAX_FOOD_AMOUNT, 'wrong cherry amount');
+        assert(food_count == 2, 'Should have exactly 2 foods');
+        println!("Initial food test passed: {} foods found", food_count);
     }
 
     #[test]
@@ -65,9 +64,11 @@ mod tests {
 
         // Create player, food, and beast
         player_system.spawn_player();
-        player_system.add_initial_food();
         game_system.spawn_beast(1, 3); // Spawn beast with specie 1
         player_system.set_current_beast(1);
+
+        // Add initial food after we have a player, a beast and the beast associated with the player
+        game_system.add_initial_food(1);
 
         // Get initial status
         let initial_status: BeastStatus = game_system.get_timestamp_based_status();
@@ -104,9 +105,11 @@ mod tests {
 
         // Create player, food, and beast
         player_system.spawn_player();
-        player_system.add_initial_food();
         game_system.spawn_beast(1, 1); // Spawn beast with specie 1
         player_system.set_current_beast(1);
+
+        // Add initial food after we have a player, a beast and the beast associated with the player
+        game_system.add_initial_food(1);
 
         // We decrease the status to verify that they increase after feeding
         cheat_block_timestamp(7000500);
@@ -147,26 +150,90 @@ mod tests {
 
         // Initialize player and add initial food
         player_system.spawn_player();
-        player_system.add_initial_food();
+        game_system.spawn_beast(1, 1); // Spawn beast with specie 1
+        player_system.set_current_beast(1);
 
-        // Get initial apple amount
-        let initial_apple: Food = world.read_model((PLAYER(), 1)); // 1 is the ID for apple
-        let initial_amount = initial_apple.amount;
+        let test_food_id: u8 = 5; // CakeChocolate
+        let initial_amount: u8 = 10;
 
-        // Update food amount (add 5 more apples)
+        game_system.add_or_update_food_amount(test_food_id, initial_amount);
+
+        // Verify that the food was created correctly
+        let initial_food: Food = world.read_model((PLAYER(), test_food_id));
+        assert(initial_food.amount == initial_amount, 'Initial amount incorrect');
+
+        // Update the food amount (add 5 more)
         let additional_amount: u8 = 5;
-        game_system.update_food_amount(1, additional_amount);
+        game_system.add_or_update_food_amount(test_food_id, additional_amount);
 
-        // Read updated food amount
-        let updated_apple: Food = world.read_model((PLAYER(), 1));
+        // Read the updated food amount
+        let updated_food: Food = world.read_model((PLAYER(), test_food_id));
 
-        // Verify amount increased correctly
+        // Verify that the amount increased correctly
         assert(
-            updated_apple.amount == initial_amount + additional_amount, 'incorrect update amount',
+            updated_food.amount == initial_amount + additional_amount, 'Incorrect update amount',
         );
 
-        println!("Initial amount: {}, Updated amount: {}", initial_amount, updated_apple.amount);
+        println!("Initial amount: {}, Updated amount: {}", initial_amount, updated_food.amount);
     }
+
+    #[test]
+    #[available_gas(60000000)]
+    fn test_food_amount_edge_cases() {
+        // Initialize test environment
+        let world = create_test_world();
+        let player_system = create_player_system(world);
+        let game_system = create_game_system(world);
+
+        cheat_caller_address(PLAYER());
+
+        // Initialize player and add initial food
+        player_system.spawn_player();
+        game_system.spawn_beast(1, 1); // Spawn beast with specie 1
+        player_system.set_current_beast(1);
+
+        let test_food_id: u8 = 1; // Apple
+        let initial_amount: u8 = 1;
+
+        game_system.add_or_update_food_amount(test_food_id, initial_amount);
+
+        // Verify that the food was created correctly
+        let initial_food: Food = world.read_model((PLAYER(), test_food_id));
+        assert(initial_food.amount == initial_amount, 'Initial amount incorrect');
+
+        // Case 1: Reduce the amount to exactly 0 using feed
+        game_system.feed(test_food_id);
+
+        // Read the food after reducing to 0
+        let zero_food: Food = world.read_model((PLAYER(), test_food_id));
+        assert(zero_food.amount == 0, 'Amount should be zero');
+
+        println!("INITIAL FOOD: {}, UPDATED FOOD: {}", initial_amount, zero_food.amount);
+
+        // Case 2: Try to add more food after reaching 0
+        let new_amount: u8 = 3;
+        game_system.add_or_update_food_amount(test_food_id, new_amount);
+
+        // // Verify that the amount was updated correctly
+        let updated_food: Food = world.read_model((PLAYER(), test_food_id));
+
+        // // If the logic works correctly with amount 0:
+        assert(updated_food.amount == new_amount, 'Should update from zero');
+
+        // // Case 3: Create a different food and verify that both exist
+        let another_food_id: u8 = 7; // Cheese
+        game_system.add_or_update_food_amount(another_food_id, 8);
+
+        // // Verify that both foods exist with correct amounts
+        let final_first_food: Food = world.read_model((PLAYER(), test_food_id));
+        let second_food: Food = world.read_model((PLAYER(), another_food_id));
+
+        assert(final_first_food.amount == new_amount, 'First food amount changed');
+        assert(second_food.amount == 8, 'Second food amount incorrect');
+
+        println!("Edge case test passed: Food with zero amount handled correctly");
+    }
+
 
     #[test]
     #[available_gas(60000000)]
@@ -178,34 +245,56 @@ mod tests {
 
         cheat_caller_address(PLAYER());
 
-        // Initialize player and add initial food
+        // Initialize player
         player_system.spawn_player();
-        player_system.add_initial_food();
+        game_system.spawn_beast(1, 1); // Spawn beast with specie 1 (Light)
+        player_system.set_current_beast(1);
 
-        // Get initial amounts
-        let initial_apple: Food = world.read_model((PLAYER(), 1)); // Apple
-        let initial_banana: Food = world.read_model((PLAYER(), 2)); // Banana
-        let initial_beef: Food = world.read_model((PLAYER(), 13)); // Beef
+        // Create different food types
+        let apple_id: u8 = 1; // Apple
+        let banana_id: u8 = 2; // Banana
+        let beef_id: u8 = 13; // Beef
 
-        // Update multiple food types
-        game_system.update_food_amount(1, 3); // Add 3 apples
-        game_system.update_food_amount(2, 7); // Add 7 bananas
-        game_system.update_food_amount(13, 2); // Add 2 beefs
+        // Initial amount for each food
+        let apple_initial: u8 = 5;
+        let banana_initial: u8 = 8;
+        let beef_initial: u8 = 3;
+
+        // Create the foods
+        game_system.add_or_update_food_amount(apple_id, apple_initial);
+        game_system.add_or_update_food_amount(banana_id, banana_initial);
+        game_system.add_or_update_food_amount(beef_id, beef_initial);
+
+        // Verify initial amounts
+        let initial_apple: Food = world.read_model((PLAYER(), apple_id));
+        let initial_banana: Food = world.read_model((PLAYER(), banana_id));
+        let initial_beef: Food = world.read_model((PLAYER(), beef_id));
+
+        assert(initial_apple.amount == apple_initial, 'Apple init failed');
+        assert(initial_banana.amount == banana_initial, 'Banana init failed');
+        assert(initial_beef.amount == beef_initial, 'Beef init failed');
+
+        // Update the amounts
+        let apple_add: u8 = 3;
+        let banana_add: u8 = 7;
+        let beef_add: u8 = 2;
+
+        game_system.add_or_update_food_amount(apple_id, apple_add); // Add apples
+        game_system.add_or_update_food_amount(banana_id, banana_add); // Add bananas
+        game_system.add_or_update_food_amount(beef_id, beef_add); // Add beefs
 
         // Read updated amounts
-        let updated_apple: Food = world.read_model((PLAYER(), 1));
-        let updated_banana: Food = world.read_model((PLAYER(), 2));
-        let updated_beef: Food = world.read_model((PLAYER(), 13));
+        let updated_apple: Food = world.read_model((PLAYER(), apple_id));
+        let updated_banana: Food = world.read_model((PLAYER(), banana_id));
+        let updated_beef: Food = world.read_model((PLAYER(), beef_id));
 
-        // Verify all amounts increased correctly
-        assert(updated_apple.amount == initial_apple.amount + 3, 'apple update failed');
-        assert(updated_banana.amount == initial_banana.amount + 7, 'banana update failed');
-        assert(updated_beef.amount == initial_beef.amount + 2, 'beef update failed');
+        // Verify that all amounts increased correctly
+        assert(updated_apple.amount == apple_initial + apple_add, 'apple update failed');
+        assert(updated_banana.amount == banana_initial + banana_add, 'banana update failed');
+        assert(updated_beef.amount == beef_initial + beef_add, 'beef update failed');
 
         println!("Apple: {} -> {}", initial_apple.amount, updated_apple.amount);
         println!("Banana: {} -> {}", initial_banana.amount, updated_banana.amount);
         println!("Beef: {} -> {}", initial_beef.amount, updated_beef.amount);
     }
-
-
 }

--- a/dojo/src/tests/test_food.cairo
+++ b/dojo/src/tests/test_food.cairo
@@ -32,7 +32,7 @@ mod tests {
         game_system.spawn_beast(1, 1); 
         player_system.set_current_beast(1);
 
-        game_system.add_initial_food(1);
+        player_system.add_initial_food(1);
 
         let mut food_count = 0;
         let mut k: u8 = 1; 
@@ -68,7 +68,7 @@ mod tests {
         player_system.set_current_beast(1);
 
         // Add initial food after we have a player, a beast and the beast associated with the player
-        game_system.add_initial_food(1);
+        player_system.add_initial_food(1);
 
         // Get initial status
         let initial_status: BeastStatus = game_system.get_timestamp_based_status();
@@ -109,7 +109,7 @@ mod tests {
         player_system.set_current_beast(1);
 
         // Add initial food after we have a player, a beast and the beast associated with the player
-        game_system.add_initial_food(1);
+        player_system.add_initial_food(1);
 
         // We decrease the status to verify that they increase after feeding
         cheat_block_timestamp(7000500);
@@ -156,7 +156,7 @@ mod tests {
         let test_food_id: u8 = 5; // CakeChocolate
         let initial_amount: u8 = 10;
 
-        game_system.add_or_update_food_amount(test_food_id, initial_amount);
+        player_system.add_or_update_food_amount(test_food_id, initial_amount);
 
         // Verify that the food was created correctly
         let initial_food: Food = world.read_model((PLAYER(), test_food_id));
@@ -164,7 +164,7 @@ mod tests {
 
         // Update the food amount (add 5 more)
         let additional_amount: u8 = 5;
-        game_system.add_or_update_food_amount(test_food_id, additional_amount);
+        player_system.add_or_update_food_amount(test_food_id, additional_amount);
 
         // Read the updated food amount
         let updated_food: Food = world.read_model((PLAYER(), test_food_id));
@@ -195,7 +195,7 @@ mod tests {
         let test_food_id: u8 = 1; // Apple
         let initial_amount: u8 = 1;
 
-        game_system.add_or_update_food_amount(test_food_id, initial_amount);
+        player_system.add_or_update_food_amount(test_food_id, initial_amount);
 
         // Verify that the food was created correctly
         let initial_food: Food = world.read_model((PLAYER(), test_food_id));
@@ -212,7 +212,7 @@ mod tests {
 
         // Case 2: Try to add more food after reaching 0
         let new_amount: u8 = 3;
-        game_system.add_or_update_food_amount(test_food_id, new_amount);
+        player_system.add_or_update_food_amount(test_food_id, new_amount);
 
         // // Verify that the amount was updated correctly
         let updated_food: Food = world.read_model((PLAYER(), test_food_id));
@@ -222,7 +222,7 @@ mod tests {
 
         // // Case 3: Create a different food and verify that both exist
         let another_food_id: u8 = 7; // Cheese
-        game_system.add_or_update_food_amount(another_food_id, 8);
+        player_system.add_or_update_food_amount(another_food_id, 8);
 
         // // Verify that both foods exist with correct amounts
         let final_first_food: Food = world.read_model((PLAYER(), test_food_id));
@@ -261,9 +261,9 @@ mod tests {
         let beef_initial: u8 = 3;
 
         // Create the foods
-        game_system.add_or_update_food_amount(apple_id, apple_initial);
-        game_system.add_or_update_food_amount(banana_id, banana_initial);
-        game_system.add_or_update_food_amount(beef_id, beef_initial);
+        player_system.add_or_update_food_amount(apple_id, apple_initial);
+        player_system.add_or_update_food_amount(banana_id, banana_initial);
+        player_system.add_or_update_food_amount(beef_id, beef_initial);
 
         // Verify initial amounts
         let initial_apple: Food = world.read_model((PLAYER(), apple_id));
@@ -279,9 +279,9 @@ mod tests {
         let banana_add: u8 = 7;
         let beef_add: u8 = 2;
 
-        game_system.add_or_update_food_amount(apple_id, apple_add); // Add apples
-        game_system.add_or_update_food_amount(banana_id, banana_add); // Add bananas
-        game_system.add_or_update_food_amount(beef_id, beef_add); // Add beefs
+        player_system.add_or_update_food_amount(apple_id, apple_add); // Add apples
+        player_system.add_or_update_food_amount(banana_id, banana_add); // Add bananas
+        player_system.add_or_update_food_amount(beef_id, beef_add); // Add beefs
 
         // Read updated amounts
         let updated_apple: Food = world.read_model((PLAYER(), apple_id));

--- a/dojo/src/tests/test_status.cairo
+++ b/dojo/src/tests/test_status.cairo
@@ -26,7 +26,7 @@ mod tests {
         player_system.set_current_beast(1);
 
         // Add initial food after we have a player, a beast and the beast associated with the player
-        game_system.add_initial_food(1);
+        player_system.add_initial_food(1);
 
         // Get new timestamp calculated status
         cheat_block_timestamp(7005000);
@@ -101,7 +101,7 @@ mod tests {
         player_system.set_current_beast(1);
 
         // Add initial food after we have a player, a beast and the beast associated with the player
-        game_system.add_initial_food(1);
+        player_system.add_initial_food(1);
 
         // Get new timestamp calculated status
         cheat_block_timestamp(7005000);

--- a/dojo/src/tests/test_status.cairo
+++ b/dojo/src/tests/test_status.cairo
@@ -22,9 +22,11 @@ mod tests {
 
         // Create player, food, and beast
         player_system.spawn_player();
-        player_system.add_initial_food();
         game_system.spawn_beast(1, 1); // Spawn beast with specie 1
         player_system.set_current_beast(1);
+
+        // Add initial food after we have a player, a beast and the beast associated with the player
+        game_system.add_initial_food(1);
 
         // Get new timestamp calculated status
         cheat_block_timestamp(7005000);
@@ -95,9 +97,11 @@ mod tests {
 
         // Create player, food, and beast
         player_system.spawn_player();
-        player_system.add_initial_food();
         game_system.spawn_beast(1, 1); // Spawn beast with specie 1
         player_system.set_current_beast(1);
+
+        // Add initial food after we have a player, a beast and the beast associated with the player
+        game_system.add_initial_food(1);
 
         // Get new timestamp calculated status
         cheat_block_timestamp(7005000);


### PR DESCRIPTION
## Implement Refactor and Random Food Init
- Closes #299 

### Changes
- Replaced static food initialization with a random system where each new beast starts with only 2 food types
- Implemented random selection logic to provide one favorite food and one common food based on beast type 
- Added `get_random_favorite_food` and `get_random_common_food` methods to Beast model
- Modified `add_initial_food` to accept beast_id parameter and use random selection
- Created `add_or_update_food_amount` method to handle food creation and updates

### Testing
- Added comprehensive tests for random food initialization
- Created edge case tests to verify proper handling of food with zero amount
- Updated existing tests to accommodate new initialization pattern
- Verified full compatibility with existing beast feeding mechanics

### Client Workflow
- First you should call spawn player.
- Second you should validate spawn beast is called (we need a beast)
- Then, set current beast to the player
- Finally, call the food to show that for the users.

Why? Because now the init food is in the spawn beast instead the spawn player


<img width="668" alt="image" src="https://github.com/user-attachments/assets/0f378576-285d-4db8-911c-275e06a01afe" />


