### PR TITLE
[Refactor]: Remove redundant initial food setup

### DIFF
--- a/dojo/src/systems/game.cairo
+++ b/dojo/src/systems/game.cairo
@@ -57,9 +57,6 @@ pub mod game {
     #[allow(unused_imports)]
     use dojo::world::{WorldStorage, WorldStorageTrait};
 
-    // Player imports
-    use tamagotchi::systems::player::{IPlayerDispatcher, IPlayerDispatcherTrait};
-
      // Storage
      #[storage]
      struct Storage {
@@ -84,9 +81,7 @@ pub mod game {
             store.new_beast_status(current_beast_id);
             store.new_beast(current_beast_id, specie, beast_type);
 
-            let (contract_address,_ ) = world.dns(@"player").unwrap();
-            let player_system_dispatcher = IPlayerDispatcher { contract_address };
-            player_system_dispatcher.add_initial_food(current_beast_id);
+            store.init_player_food(current_beast_id);
 
             self.beast_counter.write(current_beast_id+1);
         }

--- a/dojo/src/systems/player.cairo
+++ b/dojo/src/systems/player.cairo
@@ -3,7 +3,6 @@
 pub trait IPlayer<T> {
     // ------------------------- Player methods -------------------------
     fn spawn_player(ref self: T);
-    fn add_initial_food(ref self: T, beast_id: u16);
     fn set_current_beast(ref self: T, beast_id: u16);
     fn update_player_daily_streak(ref self: T);
     fn update_player_total_points(ref self: T, points: u32);
@@ -44,13 +43,6 @@ pub mod player {
             let store = StoreTrait::new(world);
 
             store.new_player();
-        }
-
-        fn add_initial_food(ref self: ContractState, beast_id: u16) {
-            let mut world = self.world(@"tamagotchi");
-            let store = StoreTrait::new(world);
-
-            store.init_player_food(beast_id);
         }
         
         fn set_current_beast(ref self: ContractState, beast_id: u16) {

--- a/dojo/src/tests/test_status.cairo
+++ b/dojo/src/tests/test_status.cairo
@@ -25,9 +25,6 @@ mod tests {
         game_system.spawn_beast(1, 1); // Spawn beast with specie 1
         player_system.set_current_beast(1);
 
-        // Add initial food after we have a player, a beast and the beast associated with the player
-        player_system.add_initial_food(1);
-
         // Get new timestamp calculated status
         cheat_block_timestamp(7005000);
         let decreased_status: BeastStatus = game_system.get_timestamp_based_status();
@@ -99,9 +96,6 @@ mod tests {
         player_system.spawn_player();
         game_system.spawn_beast(1, 1); // Spawn beast with specie 1
         player_system.set_current_beast(1);
-
-        // Add initial food after we have a player, a beast and the beast associated with the player
-        player_system.add_initial_food(1);
 
         // Get new timestamp calculated status
         cheat_block_timestamp(7005000);


### PR DESCRIPTION
## Remove redundant initial food setup
- Closes #308 

### Changes
- Identified and resolved issues through extensive debugging
- Eliminated unnecessary abstraction layer between systems
- Fixed initialization flow by removing redundant player system calls (```add_initial_food```), now just the ```store.init_player_food()```

### Tests

<img width="471" alt="image" src="https://github.com/user-attachments/assets/728d98e1-a912-47ab-bfe4-a84d57f95afb" />
