### PR TITLE
Fix hashrouter

### DIFF
--- a/client/dev-dist/sw.js
+++ b/client/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-20a2f87f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.2hq18g0abi8"
+    "revision": "0.8m5ej0jiub"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/client/src/components/Main/index.tsx
+++ b/client/src/components/Main/index.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { HashRouter as Router, Routes, Route } from "react-router-dom";
 import FullscreenGame from "../FullScreenGame/FullScreenGame";
 import Leaderboard from "../Leadeboard";
 import NewCover from "../NewCover";


### PR DESCRIPTION
Ticket
- https://bytebeasts.atlassian.net/browse/BB-39

Solution
- https://stackoverflow.com/questions/27928372/react-router-urls-dont-work-when-refreshing-or-writing-manually

If you're using HashRouter instead of BrowserRouter, this problem doesn’t happen — because all routing happens after the #, which is never sent to the server. But HashRouter URLs look messier (e.g., /#/about).