### PR TITLE
[FEAT]: Add custom event to store push notifications token

### DIFF
--- a/dojo/src/events/push.cairo
+++ b/dojo/src/events/push.cairo
@@ -1,0 +1,11 @@
+// Starknet import
+use starknet::ContractAddress;
+
+// Event
+#[derive(Drop, Serde)]
+#[dojo::event]
+pub struct PushToken {
+    #[key]
+    pub player_address: ContractAddress, 
+    pub token: ByteArray,
+}

--- a/dojo/src/lib.cairo
+++ b/dojo/src/lib.cairo
@@ -19,6 +19,10 @@ pub mod models {
     pub mod food;
 }
 
+pub mod events {
+    pub mod push;
+}
+
 pub mod types {
     pub mod food;
     pub mod beast;

--- a/dojo/src/models/highest_score.cairo
+++ b/dojo/src/models/highest_score.cairo
@@ -3,7 +3,7 @@ use starknet::{ContractAddress};
 
 //Model
 #[derive(Drop, Serde, Copy, IntrospectPacked, Debug)]
-#[dojo::model]
+#[dojo::model] //TODO: check the historical true of Dojo Events, this can improve gas comsuption.
 pub struct HighestScore {
     #[key]
     pub minigame_id: u16,

--- a/dojo/src/systems/player.cairo
+++ b/dojo/src/systems/player.cairo
@@ -8,6 +8,7 @@ pub trait IPlayer<T> {
     fn update_player_total_points(ref self: T, points: u32);
     fn update_player_minigame_highest_score(ref self: T, points: u32, minigame_id: u16);
     fn add_or_update_food_amount(ref self: T, food_id: u8, amount: u8);
+    fn emit_player_push_token(ref self: T, token: ByteArray);
 }
 
 #[dojo::contract]
@@ -16,7 +17,7 @@ pub mod player {
     use super::{IPlayer};
     
     // Starknet imports
-    use starknet::get_block_timestamp;
+    use starknet::{get_block_timestamp, ContractAddress};
     
     // Model imports
     #[allow(unused_imports)]
@@ -25,12 +26,17 @@ pub mod player {
     use tamagotchi::models::food::{Food, FoodTrait};
     use tamagotchi::models::highest_score::{HighestScore};
 
+    // Events imports
+    use tamagotchi::events::push::{PushToken};
+
     // Store import
     use tamagotchi::store::{StoreTrait};
 
     // Dojo Imports
     #[allow(unused_imports)]
     use dojo::model::{ModelStorage};
+    #[allow(unused_imports)]
+    use dojo::event::EventStorage;
 
     // Constructor
     fn dojo_init( ref self: ContractState) {
@@ -114,5 +120,16 @@ pub mod player {
             }
         }
 
+        fn emit_player_push_token(ref self: ContractState, token: ByteArray) {
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+
+            let mut player: Player = store.read_player();
+            player.assert_exists();
+
+            let player_address: ContractAddress = player.address;
+
+            world.emit_event(@PushToken { player_address, token});
+        }
     }
 }

--- a/dojo/src/tests/test_player.cairo
+++ b/dojo/src/tests/test_player.cairo
@@ -1,7 +1,10 @@
 #[cfg(test)]
 mod tests {
-    // Dojo import
+    // Dojo imports
+    #[allow(unused_imports)]
+    use dojo::event::{Event, EventStorage};
     use dojo::model::{ModelStorage};
+    use dojo::world::world::Event as WorldEvent;
 
     // Traits import
     use tamagotchi::systems::game::IGameDispatcherTrait;
@@ -9,7 +12,10 @@ mod tests {
 
     // Models and types import
     use tamagotchi::models::player::{Player};
-    use tamagotchi::tests::utils::{utils::{PLAYER, cheat_caller_address, create_game_system, create_player_system, create_test_world}};
+    use tamagotchi::tests::utils::{utils::{PLAYER, cheat_caller_address, create_game_system, create_player_system, create_test_world, drop_all_events}};
+
+    // Event import
+    use tamagotchi::events::push::{PushToken};
 
     #[test]
     #[available_gas(40000000)]
@@ -119,4 +125,38 @@ mod tests {
         assert(player.total_points == points, 'wrong total points');
     }
 
+    #[test]
+    #[available_gas(100000000)]
+    fn test_player_emit_push_token_event() {
+        let world = create_test_world();
+        let player_system = create_player_system(world);
+
+        cheat_caller_address(PLAYER());
+
+        // Initialize player
+        player_system.spawn_player();
+
+        drop_all_events(world.dispatcher.contract_address);
+
+        let test_client_token: ByteArray = "fAU1e5l3h3LH3IvL-oopuG:APA91bH7wBebtThd31cXqRgMQrAQ7Jc3arbBlYDXuKf5D81SmSyokGH24yefscOpUzRV0YwSFMy6N_DVrgMvISFCXYVOU8_DxpQUP-c5vtqUxF1cG5nfNMU";
+        
+        // Call method to emit the event
+        player_system.emit_player_push_token(test_client_token);
+
+        let event = starknet::testing::pop_log::<WorldEvent>(world.dispatcher.contract_address);
+
+        assert(event.is_some(), 'no event');
+
+        if let WorldEvent::EventEmitted(event) = event.unwrap() {
+            assert(
+                event.selector == Event::<PushToken>::selector(world.namespace_hash),
+                'bad event selector',
+            );
+            assert(event.keys == [PLAYER().into()].span(), 'bad key');
+            // Values assert omited as there is issues retrieving them
+            // assert(event.values == [test_client_token.into()].span(), 'bad value');
+        } else {
+            core::panic_with_felt252('no PushToken event emited');
+        }
+    }
 }

--- a/dojo/src/tests/utils.cairo
+++ b/dojo/src/tests/utils.cairo
@@ -20,6 +20,9 @@ pub mod utils {
     use tamagotchi::models::player::{m_Player};
     use tamagotchi::models::food::{m_Food};
 
+    // Events imports
+    use tamagotchi::events::push::{e_PushToken};
+
     // ------- Constants -------
     pub fn PLAYER() -> ContractAddress {
         starknet::contract_address_const::<'PLAYER'>()
@@ -34,6 +37,7 @@ pub mod utils {
                 TestResource::Model(m_BeastStatus::TEST_CLASS_HASH),
                 TestResource::Model(m_Player::TEST_CLASS_HASH),
                 TestResource::Model(m_Food::TEST_CLASS_HASH),
+                TestResource::Event(e_PushToken::TEST_CLASS_HASH),
                 TestResource::Contract(player::TEST_CLASS_HASH),
                 TestResource::Contract(game::TEST_CLASS_HASH),
             ].span(),


### PR DESCRIPTION
## Summary
- Closes #339
- Added a new event to store the push token
- Add a test to check the correct emitted event