### PR TITLE
[FEAT]: Add initial version of achievements - minigames

### DIFF
--- a/dojo/dojo_dev.toml
+++ b/dojo/dojo_dev.toml
@@ -21,6 +21,6 @@ private_key = "0x33003003001800009900180300d206308b0070db00121318d17b5e6262150b"
 # world_address = "0x06171ed98331e849d6084bf2b3e3186a7ddf35574dd68cab4691053ee8ab69d7"
 
 [writers]
-"tamagotchi" = ["tamagotchi-game", "tamagotchi-player"]
+"tamagotchi" = ["tamagotchi-game", "tamagotchi-player", "tamagotchi-achieve]
 "tamagotchi-TrophyCreation" = ["tamagotchi-player"]
 "tamagotchi-TrophyProgression" = ["tamagotchi-player"]

--- a/dojo/dojo_sepolia.toml
+++ b/dojo/dojo_sepolia.toml
@@ -18,6 +18,6 @@ default = "tamagotchi"
 rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
 
 [writers]
-"tamagotchi" = ["tamagotchi-game", "tamagotchi-player"]
+"tamagotchi" = ["tamagotchi-game", "tamagotchi-player", "tamagotchi-achieve]
 "tamagotchi-TrophyCreation" = ["tamagotchi-player"]
 "tamagotchi-TrophyProgression" = ["tamagotchi-player"]

--- a/dojo/src/achievements/achievement.cairo
+++ b/dojo/src/achievements/achievement.cairo
@@ -37,25 +37,25 @@ pub impl AchievementImpl of AchievementTrait {
     fn identifier(self: Achievement) -> felt252 {
         match self {
             Achievement::None => 0,
-            Achievement::MiniGamer => 'MiniGamer',
-            Achievement::MasterGamer => 'MasterGamer',
-            Achievement::LegendGamer => 'LegendGamer',
-            Achievement::AllStarGamer => 'AllStarGamer',
-            Achievement::ScoreHunterI => 'ScoreHunterI',
-            Achievement::ScoreHunterII => 'ScoreHunterII',
-            Achievement::ScoreHunterIII => 'ScoreHunterIII',
-            Achievement::ScoreHunterIV => 'ScoreHunterIV',
-            Achievement::ScoreHunterV => 'ScoreHunterV',
-            Achievement::JumperI => 'JumperI',
-            Achievement::JumperII => 'JumperII',
-            Achievement::JumperIII => 'JumperIII',
-            Achievement::JumperIV => 'JumperIV',
-            Achievement::JumperV => 'JumperV',
-            Achievement::TangoI => 'TangoI',
-            Achievement::TangoII => 'TangoII',
-            Achievement::TangoIII => 'TangoIII',
-            Achievement::TangoIV => 'TangoIV',
-            Achievement::TangoV => 'TangoV',
+            Achievement::MiniGamer => 'MiniGamer', // Play a minigame once
+            Achievement::MasterGamer => 'MasterGamer', // Play a minigame 15 times
+            Achievement::LegendGamer => 'LegendGamer', // Play a minigame 30 times
+            Achievement::AllStarGamer => 'AllStarGamer', // Play a minigame 50 times 
+            Achievement::ScoreHunterI => 'ScoreHunterI', // Get 2000 total points from minigames
+            Achievement::ScoreHunterII => 'ScoreHunterII', // Get 5000 total points from minigames
+            Achievement::ScoreHunterIII => 'ScoreHunterIII', // Get 12000 total points from minigames
+            Achievement::ScoreHunterIV => 'ScoreHunterIV', // Get 20000 total points from minigames
+            Achievement::ScoreHunterV => 'ScoreHunterV', // Get 50000 total points from minigames
+            Achievement::JumperI => 'JumperI', // Reach 500 points in a single platform game
+            Achievement::JumperII => 'JumperII', // Reach 1500 points in a single platform game
+            Achievement::JumperIII => 'JumperIII', // Reach 2500 points in a single platform game
+            Achievement::JumperIV => 'JumperIV', // Reach 3500 points in a single platform game
+            Achievement::JumperV => 'JumperV', // Reach 4500 points in a single platform game
+            Achievement::TangoI => 'TangoI', // Reach 25 points in a single flappy beasts game
+            Achievement::TangoII => 'TangoII', // Reach 50 points in a single flappy beasts game
+            Achievement::TangoIII => 'TangoIII', // Reach 100 points in a single flappy beasts game
+            Achievement::TangoIV => 'TangoIV', // Reach 200 points in a single flappy beasts game
+            Achievement::TangoV => 'TangoV', // Reach 350 points in a single flappy beasts game
         }
     }
 
@@ -280,30 +280,30 @@ pub impl AchievementImpl of AchievementTrait {
         match self {
             Achievement::None => "",
             // Gamer progression
-            Achievement::MiniGamer => "Embark on your first gaming adventure! A true novice.",
-            Achievement::MasterGamer => "You've honed your skills and mastered the art of gaming.",
-            Achievement::LegendGamer => "You are a legendary figure in the ByteBeasts world, a true hero.",
-            Achievement::AllStarGamer => "The ultimate champion, a master of all things gaming.",
+            Achievement::MiniGamer => "Play a minigame once.",
+            Achievement::MasterGamer => "Play a minigame 15 times.",
+            Achievement::LegendGamer => "Play a minigame 30 times.",
+            Achievement::AllStarGamer => "Play a minigame 50 times.",
             // ScoreHunter levels
-            Achievement::ScoreHunterI => "You've set your sights on the highest scores, aiming for precision.",
-            Achievement::ScoreHunterII => "Your aim is true, and you've become a true score hunter.",
-            Achievement::ScoreHunterIII => "You are a pro at hunting high scores, an unstoppable force.",
-            Achievement::ScoreHunterIV => "Legends are made with your skills, and your name echoes among the greatest.",
-            Achievement::ScoreHunterV => "You are the master of scores, no one can match your precision.",
+            Achievement::ScoreHunterI => "Get 2000 total points from minigames.",
+            Achievement::ScoreHunterII => "Get 5000 total points from minigames.",
+            Achievement::ScoreHunterIII => "Get 12000 total points from minigames.",
+            Achievement::ScoreHunterIV => "Get 20000 total points from minigames.",
+            Achievement::ScoreHunterV => "Get 50000 total points from minigames.",
             // Jumper (platform game)
-            Achievement::JumperI => "A small step, but a leap toward greatness. The world is at your feet.",
-            Achievement::JumperII => "You've taken to the skies, ready to jump higher and further.",
-            Achievement::JumperIII => "Scaling new heights, you've become a master of jumps.",
-            Achievement::JumperIV => "The mountains don't scare you anymore; you're on top of the world.",
-            Achievement::JumperV => "Your leaps defy gravity itself, as you ride rockets into the unknown.",
+            Achievement::JumperI => "Reach 500 points in a single platform game.",
+            Achievement::JumperII => "Reach 1500 points in a single platform game.",
+            Achievement::JumperIII => "Reach 2500 points in a single platform game.",
+            Achievement::JumperIV => "Reach 3500 points in a single platform game.",
+            Achievement::JumperV => "Reach 4500 points in a single platform game.",
             // Tango (flappy beasts game)
-            Achievement::TangoI => "You have got the moves! Glide through the air with elegance.",
-            Achievement::TangoII => "The wind is your friend, helping you soar through the skies.",
-            Achievement::TangoIII => "You have embraced the adventure of flight, an unstoppable flapper.",
-            Achievement::TangoIV => "Clouds are your playground as you dance across the sky.",
-            Achievement::TangoV => "You rule the skies now, flying at lightning speeds like a true king.",
+            Achievement::TangoI => "Reach 25 points in a single flappy beasts game.",
+            Achievement::TangoII => "Reach 50 points in a single flappy beasts game.",
+            Achievement::TangoIII => "Reach 100 points in a single flappy beasts game.",
+            Achievement::TangoIV => "Reach 200 points in a single flappy beasts game.",
+            Achievement::TangoV => "Reach 350 points in a single flappy beasts game.",
         }
-    }
+    }    
 
     #[inline]
     fn tasks(self: Achievement) -> Span<Task> {
@@ -312,9 +312,9 @@ pub impl AchievementImpl of AchievementTrait {
             Achievement::None => [].span(),
             // Gamer progression
             Achievement::MiniGamer => array![TaskTrait::new('MINIGAMER', 1, "Embark on your first gaming adventure! A true novice.")].span(),
-            Achievement::MasterGamer => array![TaskTrait::new('MASTERGAMER', 1, "You've honed your skills and mastered the art of gaming.")].span(),
-            Achievement::LegendGamer => array![TaskTrait::new('LEGENDGAMER', 1, "You are a legendary figure in the gaming world, a true hero.")].span(),
-            Achievement::AllStarGamer => array![TaskTrait::new('ALLSTARGAMER', 1, "The ultimate champion, a master of all things gaming.")].span(),
+            Achievement::MasterGamer => array![TaskTrait::new('MASTERGAMER', 15, "You've honed your skills and mastered the art of gaming.")].span(),
+            Achievement::LegendGamer => array![TaskTrait::new('LEGENDGAMER', 30, "You are a legendary figure in the gaming world, a true hero.")].span(),
+            Achievement::AllStarGamer => array![TaskTrait::new('ALLSTARGAMER', 50, "The ultimate champion, a master of all things gaming.")].span(),
             // ScoreHunter levels
             Achievement::ScoreHunterI => array![TaskTrait::new('SCOREHUNTERI', 1, "You've set your sights on the highest scores, aiming for precision.")].span(),
             Achievement::ScoreHunterII => array![TaskTrait::new('SCOREHUNTERII', 1, "Your aim is true, and you've become a true score hunter.")].span(),

--- a/dojo/src/achievements/achievement.cairo
+++ b/dojo/src/achievements/achievement.cairo
@@ -1,0 +1,404 @@
+// Achievement enum
+#[derive(Copy, Drop)]
+enum Achievement {
+    None,
+    // Minigames
+    MiniGamer,
+    MasterGamer,
+    LegendGamer,
+    AllStarGamer,
+    ScoreHunterI,
+    ScoreHunterII,
+    ScoreHunterIII,
+    ScoreHunterIV,
+    ScoreHunterV,
+    JumperI,
+    JumperII,
+    JumperIII,
+    JumperIV,
+    JumperV,
+    TangoI,
+    TangoII,
+    TangoIII,
+    TangoIV,
+    TangoV,
+}
+
+
+#[generate_trait]
+impl AchievementImpl of AchievementTrait {
+    #[inline]
+    fn identifier(self: Achievement) -> felt252 {
+        match self {
+            Achievement::None => 0,
+            Achievement::MiniGamer => "MiniGamer",
+            Achievement::MasterGamer => "MasterGamer",
+            Achievement::LegendGamer => "LegendGamer",
+            Achievement::AllStarGamer => "AllStarGamer",
+            Achievement::ScoreHunterI => "ScoreHunterI",
+            Achievement::ScoreHunterII => "ScoreHunterII",
+            Achievement::ScoreHunterIII => "ScoreHunterIII",
+            Achievement::ScoreHunterIV => "ScoreHunterIV",
+            Achievement::ScoreHunterV => "ScoreHunterV",
+            Achievement::JumperI => "JumperI",
+            Achievement::JumperII => "JumperII",
+            Achievement::JumperIII => "JumperIII",
+            Achievement::JumperIV => "JumperIV",
+            Achievement::JumperV => "JumperV",
+            Achievement::TangoI => "TangoI",
+            Achievement::TangoII => "TangoII",
+            Achievement::TangoIII => "TangoIII",
+            Achievement::TangoIV => "TangoIV",
+            Achievement::TangoV => "TangoV",
+        }
+    }
+
+    #[inline]
+    fn hidden(self: Achievement) -> bool {
+        match self {
+            Achievement::None => true,
+            Achievement::MiniGamer => false,
+            Achievement::MasterGamer => false,
+            Achievement::LegendGamer => false,
+            Achievement::AllStarGamer => false,
+            Achievement::ScoreHunterI => false,
+            Achievement::ScoreHunterII => false,
+            Achievement::ScoreHunterIII => false,
+            Achievement::ScoreHunterIV => false,
+            Achievement::ScoreHunterV => false,
+            Achievement::JumperI => false,
+            Achievement::JumperII => false,
+            Achievement::JumperIII => false,
+            Achievement::JumperIV => false,
+            Achievement::JumperV => false,
+            Achievement::TangoI => false,
+            Achievement::TangoII => false,
+            Achievement::TangoIII => false,
+            Achievement::TangoIV => false,
+            Achievement::TangoV => false,
+        }
+    }
+    
+
+    #[inline]
+    fn index(self: Achievement) -> u8 {
+        match self {
+            Achievement::None => 0,
+            Achievement::MiniGamer => 0,
+            Achievement::MasterGamer => 0,
+            Achievement::LegendGamer => 0,
+            Achievement::AllStarGamer => 0,
+            Achievement::ScoreHunterI => 0,
+            Achievement::ScoreHunterII => 1,
+            Achievement::ScoreHunterIII => 2,
+            Achievement::ScoreHunterIV => 3,
+            Achievement::ScoreHunterV => 4,
+            Achievement::JumperI => 0,
+            Achievement::JumperII => 1,
+            Achievement::JumperIII => 2,
+            Achievement::JumperIV => 3,
+            Achievement::JumperV => 4,
+            Achievement::TangoI => 0,
+            Achievement::TangoII => 1,
+            Achievement::TangoIII => 2,
+            Achievement::TangoIV => 3,
+            Achievement::TangoV => 4,
+        }
+    }
+
+    #[inline]
+    fn points(self: Achievement) -> u16 {
+        match self {
+            Achievement::None => 0,
+            Achievement::MiniGamer => 10,
+            Achievement::MasterGamer => 15,
+            Achievement::LegendGamer => 25,
+            Achievement::AllStarGamer => 35,
+            Achievement::ScoreHunterI => 10,
+            Achievement::ScoreHunterII => 20,
+            Achievement::ScoreHunterIII => 30,
+            Achievement::ScoreHunterIV => 40,
+            Achievement::ScoreHunterV => 50,
+            Achievement::JumperI => 10,
+            Achievement::JumperII => 20,
+            Achievement::JumperIII => 30,
+            Achievement::JumperIV => 40,
+            Achievement::JumperV => 50,
+            Achievement::TangoI => 10,
+            Achievement::TangoII => 20,
+            Achievement::TangoIII => 30,
+            Achievement::TangoIV => 40,
+            Achievement::TangoV => 50,
+        }
+    }
+
+    #[inline]
+    fn start(self: Achievement) -> u64 {
+        match self {
+            Achievement::None => 0,
+            Achievement::MiniGamer => 0,
+            Achievement::MasterGamer => 0,
+            Achievement::LegendGamer => 0,
+            Achievement::AllStarGamer => 0,
+            Achievement::ScoreHunterI => 0,
+            Achievement::ScoreHunterII => 0,
+            Achievement::ScoreHunterIII => 0,
+            Achievement::ScoreHunterIV => 0,
+            Achievement::ScoreHunterV => 0,
+            Achievement::JumperI => 0,
+            Achievement::JumperII => 0,
+            Achievement::JumperIII => 0,
+            Achievement::JumperIV => 0,
+            Achievement::JumperV => 0,
+            Achievement::TangoI => 0,
+            Achievement::TangoII => 0,
+            Achievement::TangoIII => 0,
+            Achievement::TangoIV => 0,
+            Achievement::TangoV => 0,
+        }
+    }
+
+    #[inline]
+    fn end(self: Achievement) -> u64 {
+        match self {
+            Achievement::None => 0,
+            Achievement::MiniGamer => 0,
+            Achievement::MasterGamer => 0,
+            Achievement::LegendGamer => 0,
+            Achievement::AllStarGamer => 0,
+            Achievement::ScoreHunterI => 0,
+            Achievement::ScoreHunterII => 0,
+            Achievement::ScoreHunterIII => 0,
+            Achievement::ScoreHunterIV => 0,
+            Achievement::ScoreHunterV => 0,
+            Achievement::JumperI => 0,
+            Achievement::JumperII => 0,
+            Achievement::JumperIII => 0,
+            Achievement::JumperIV => 0,
+            Achievement::JumperV => 0,
+            Achievement::TangoI => 0,
+            Achievement::TangoII => 0,
+            Achievement::TangoIII => 0,
+            Achievement::TangoIV => 0,
+            Achievement::TangoV => 0,
+        }
+    }
+
+    #[inline]
+    fn group(self: Achievement) -> felt252 {
+        match self {
+            Achievement::None => 0,
+            Achievement::MiniGamer => 'Gamer',
+            Achievement::MasterGamer => 'Gamer',
+            Achievement::LegendGamer => 'Gamer',
+            Achievement::AllStarGamer => 'Gamer',
+            Achievement::ScoreHunterI => 'ScoreHunter',
+            Achievement::ScoreHunterII => 'ScoreHunter',
+            Achievement::ScoreHunterIII => 'ScoreHunter',
+            Achievement::ScoreHunterIV => 'ScoreHunter',
+            Achievement::ScoreHunterV => 'ScoreHunter',
+            Achievement::JumperI => 'Jumper',
+            Achievement::JumperII => 'Jumper',
+            Achievement::JumperIII => 'Jumper',
+            Achievement::JumperIV => 'Jumper',
+            Achievement::JumperV => 'Jumper',
+            Achievement::TangoI => 'Tango',
+            Achievement::TangoII => 'Tango',
+            Achievement::TangoIII => 'Tango',
+            Achievement::TangoIV => 'Tango',
+            Achievement::TangoV => 'Tango',
+        }
+    }
+
+    #[inline]
+    fn icon(self: Achievement) -> felt252 {
+        match self {
+            Achievement::None => '',
+            // Gamer progression
+            Achievement::MiniGamer => 'fa-gamepad',
+            Achievement::MasterGamer => 'fa-chess-knight',
+            Achievement::LegendGamer => 'fa-dungeon',
+            Achievement::AllStarGamer => 'fa-star',
+            // ScoreHunter levels
+            Achievement::ScoreHunterI => 'fa-crosshairs',
+            Achievement::ScoreHunterII => 'fa-bullseye',
+            Achievement::ScoreHunterIII => 'fa-chart-line',
+            Achievement::ScoreHunterIV => 'fa-trophy',
+            Achievement::ScoreHunterV => 'fa-crown',
+            // Jumper (platform game)
+            Achievement::JumperI => 'fa-shoe-prints',
+            Achievement::JumperII => 'fa-arrow-up',
+            Achievement::JumperIII => 'fa-stairs',
+            Achievement::JumperIV => 'fa-mountain',
+            Achievement::JumperV => 'fa-rocket',
+            // Tango (flappy beasts game)
+            Achievement::TangoI => 'fa-feather',
+            Achievement::TangoII => 'fa-wind',
+            Achievement::TangoIII => 'fa-bird',
+            Achievement::TangoIV => 'fa-cloud-arrow-up',
+            Achievement::TangoV => 'fa-jet-fighter',
+        }
+    }
+    
+    #[inline]
+    fn title(self: Achievement) -> felt252 {
+        match self {
+            Achievement::None => '',
+            // Gamer progression
+            Achievement::MiniGamer => 'Novice Explorer',
+            Achievement::MasterGamer => 'Tactician',
+            Achievement::LegendGamer => 'Heroic Gamer',
+            Achievement::AllStarGamer => 'Ultimate Champion',
+            // ScoreHunter levels
+            Achievement::ScoreHunterI => 'Sharpshooter',
+            Achievement::ScoreHunterII => 'Precision Seeker',
+            Achievement::ScoreHunterIII => 'High Roller',
+            Achievement::ScoreHunterIV => 'Legendary Sniper',
+            Achievement::ScoreHunterV => 'Master Hunter',
+            // Jumper (platform game)
+            Achievement::JumperI => 'First Leap',
+            Achievement::JumperII => 'Skyward Bound',
+            Achievement::JumperIII => 'Tower Climber',
+            Achievement::JumperIV => 'Mountain Conqueror',
+            Achievement::JumperV => 'Rocket Rider',
+            // Tango (flappy beasts game)
+            Achievement::TangoI => 'Feathered Friend',
+            Achievement::TangoII => 'Wind Dancer',
+            Achievement::TangoIII => 'Soaring Adventurer',
+            Achievement::TangoIV => 'Cloud Chaser',
+            Achievement::TangoV => 'Sky King',
+        }
+    }
+
+    #[inline]
+    fn description(self: Achievement) -> ByteArray {
+        match self {
+            Achievement::None => "",
+            // Gamer progression
+            Achievement::MiniGamer => "Embark on your first gaming adventure! A true novice.",
+            Achievement::MasterGamer => "You've honed your skills and mastered the art of gaming.",
+            Achievement::LegendGamer => "You are a legendary figure in the ByteBeasts world, a true hero.",
+            Achievement::AllStarGamer => "The ultimate champion, a master of all things gaming.",
+            // ScoreHunter levels
+            Achievement::ScoreHunterI => "You've set your sights on the highest scores, aiming for precision.",
+            Achievement::ScoreHunterII => "Your aim is true, and you've become a true score hunter.",
+            Achievement::ScoreHunterIII => "You are a pro at hunting high scores, an unstoppable force.",
+            Achievement::ScoreHunterIV => "Legends are made with your skills, and your name echoes among the greatest.",
+            Achievement::ScoreHunterV => "You are the master of scores, no one can match your precision.",
+            // Jumper (platform game)
+            Achievement::JumperI => "A small step, but a leap toward greatness. The world is at your feet.",
+            Achievement::JumperII => "You've taken to the skies, ready to jump higher and further.",
+            Achievement::JumperIII => "Scaling new heights, you've become a master of jumps.",
+            Achievement::JumperIV => "The mountains don't scare you anymore; you're on top of the world.",
+            Achievement::JumperV => "Your leaps defy gravity itself, as you ride rockets into the unknown.",
+            // Tango (flappy beasts game)
+            Achievement::TangoI => "You have got the moves! Glide through the air with elegance.",
+            Achievement::TangoII => "The wind is your friend, helping you soar through the skies.",
+            Achievement::TangoIII => "You have embraced the adventure of flight, an unstoppable flapper.",
+            Achievement::TangoIV => "Clouds are your playground as you dance across the sky.",
+            Achievement::TangoV => "You rule the skies now, flying at lightning speeds like a true king.",
+        }
+    }
+
+    #[inline]
+    fn tasks(self: Achievement) -> Span<Task> {
+        // span structure: array![TaskTrait::new(task_id, count, description)].span(),
+        match self {
+            Achievement::None => [].span(),
+            // Gamer progression
+            Achievement::MiniGamer => array![TaskTrait::new('MINIGAMER', 1, "Embark on your first gaming adventure! A true novice.")].span(),
+            Achievement::MasterGamer => array![TaskTrait::new('MASTERGAMER', 1, "You've honed your skills and mastered the art of gaming.")].span(),
+            Achievement::LegendGamer => array![TaskTrait::new('LEGENDGAMER', 1, "You are a legendary figure in the gaming world, a true hero.")].span(),
+            Achievement::AllStarGamer => array![TaskTrait::new('ALLSTARGAMER', 1, "The ultimate champion, a master of all things gaming.")].span(),
+            // ScoreHunter levels
+            Achievement::ScoreHunterI => array![TaskTrait::new('SCOREHUNTERI', 1, "You've set your sights on the highest scores, aiming for precision.")].span(),
+            Achievement::ScoreHunterII => array![TaskTrait::new('SCOREHUNTERII', 1, "Your aim is true, and you've become a true score hunter.")].span(),
+            Achievement::ScoreHunterIII => array![TaskTrait::new('SCOREHUNTERIII', 1, "You are a pro at hunting high scores, an unstoppable force.")].span(),
+            Achievement::ScoreHunterIV => array![TaskTrait::new('SCOREHUNTERIV', 1, "Legends are made with your skills, and your name echoes among the greatest.")].span(),
+            Achievement::ScoreHunterV => array![TaskTrait::new('SCOREHUNTERV', 1, "You are the master of scores, no one can match your precision.")].span(),   
+            // Jumper (platform game)
+            Achievement::JumperI => array![TaskTrait::new('JUMPERI', 1, "A small step, but a leap toward greatness. The world is at your feet.")].span(),
+            Achievement::JumperII => array![TaskTrait::new('JUMPERII', 1, "You've taken to the skies, ready to jump higher and further.")].span(),
+            Achievement::JumperIII => array![TaskTrait::new('JUMPERIII', 1, "Scaling new heights, you've become a master of jumps.")].span(),
+            Achievement::JumperIV => array![TaskTrait::new('JUMPERIV', 1, "The mountains don't scare you anymore; you're on top of the world.")].span(),
+            Achievement::JumperV => array![TaskTrait::new('JUMPERV', 1, "Your leaps defy gravity itself, as you ride rockets into the unknown.")].span(),
+            // Tango (flappy beasts game)
+            Achievement::TangoI => array![TaskTrait::new('TANGOI', 1, "You have got the moves! Glide through the air with elegance.")].span(),
+            Achievement::TangoII => array![TaskTrait::new('TANGOII', 1, "The wind is your friend, helping you soar through the skies.")].span(),
+            Achievement::TangoIII => array![TaskTrait::new('TANGOIII', 1, "You have embraced the adventure of flight, an unstoppable flapper.")].span(),
+            Achievement::TangoIV => array![TaskTrait::new('TANGOIV', 1, "Clouds are your playground as you dance across the sky.")].span(),
+            Achievement::TangoV => array![TaskTrait::new('TANGOV', 1, "You rule the skies now, flying at lightning speeds like a true king.")].span(),
+        }        
+    }
+
+    #[inline]
+    fn data(self: Achievement) -> ByteArray {
+        ""
+    }
+}
+
+impl IntoAchievementU8 of core::Into<Achievement, u8> {
+    #[inline]
+    fn into(self: Achievement) -> u8 {
+        match self {
+            Achievement::None => 0,
+            // Minigames - General Progression
+            Achievement::MiniGamer => 1,
+            Achievement::MasterGamer => 2,
+            Achievement::LegendGamer => 3,
+            Achievement::AllStarGamer => 4,
+            // Score Hunter
+            Achievement::ScoreHunterI => 5,
+            Achievement::ScoreHunterII => 6,
+            Achievement::ScoreHunterIII => 7,
+            Achievement::ScoreHunterIV => 8,
+            Achievement::ScoreHunterV => 9,
+            // Jumper
+            Achievement::JumperI => 10,
+            Achievement::JumperII => 11,
+            Achievement::JumperIII => 12,
+            Achievement::JumperIV => 13,
+            Achievement::JumperV => 14,
+            // Tango
+            Achievement::TangoI => 15,
+            Achievement::TangoII => 16,
+            Achievement::TangoIII => 17,
+            Achievement::TangoIV => 18,
+            Achievement::TangoV => 19,
+        }
+    }
+}
+
+impl IntoU8Achievement of core::Into<u8, Achievement> {
+    #[inline]
+    fn into(self: u8) -> Achievement {
+        let value: felt252 = self.into();
+        match value {
+            0 => Achievement::None,
+            // Minigames - General Progression
+            1 => Achievement::MiniGamer,
+            2 => Achievement::MasterGamer,
+            3 => Achievement::LegendGamer,
+            4 => Achievement::AllStarGamer,
+            // Score Hunter
+            5 => Achievement::ScoreHunterI,
+            6 => Achievement::ScoreHunterII,
+            7 => Achievement::ScoreHunterIII,
+            8 => Achievement::ScoreHunterIV,
+            9 => Achievement::ScoreHunterV,
+            // Jumper
+            10 => Achievement::JumperI,
+            11 => Achievement::JumperII,
+            12 => Achievement::JumperIII,
+            13 => Achievement::JumperIV,
+            14 => Achievement::JumperV,
+            // Tango
+            15 => Achievement::TangoI,
+            16 => Achievement::TangoII,
+            17 => Achievement::TangoIII,
+            18 => Achievement::TangoIV,
+            19 => Achievement::TangoV,
+            _ => Achievement::None,
+        }
+    }
+}

--- a/dojo/src/achievements/achievement.cairo
+++ b/dojo/src/achievements/achievement.cairo
@@ -6,7 +6,7 @@ use core::traits::Into;
 
 // Achievement enum
 #[derive(Copy, Drop)]
-enum Achievement {
+pub enum Achievement {
     None,
     // Minigames
     MiniGamer,
@@ -32,7 +32,7 @@ enum Achievement {
 
 
 #[generate_trait]
-impl AchievementImpl of AchievementTrait {
+pub impl AchievementImpl of AchievementTrait {
     #[inline]
     fn identifier(self: Achievement) -> felt252 {
         match self {

--- a/dojo/src/achievements/achievement.cairo
+++ b/dojo/src/achievements/achievement.cairo
@@ -1,3 +1,9 @@
+// Dojo achievements import
+use achievement::types::task::{Task, TaskTrait}; 
+
+// Into trait import
+use core::traits::Into;
+
 // Achievement enum
 #[derive(Copy, Drop)]
 enum Achievement {
@@ -31,25 +37,25 @@ impl AchievementImpl of AchievementTrait {
     fn identifier(self: Achievement) -> felt252 {
         match self {
             Achievement::None => 0,
-            Achievement::MiniGamer => "MiniGamer",
-            Achievement::MasterGamer => "MasterGamer",
-            Achievement::LegendGamer => "LegendGamer",
-            Achievement::AllStarGamer => "AllStarGamer",
-            Achievement::ScoreHunterI => "ScoreHunterI",
-            Achievement::ScoreHunterII => "ScoreHunterII",
-            Achievement::ScoreHunterIII => "ScoreHunterIII",
-            Achievement::ScoreHunterIV => "ScoreHunterIV",
-            Achievement::ScoreHunterV => "ScoreHunterV",
-            Achievement::JumperI => "JumperI",
-            Achievement::JumperII => "JumperII",
-            Achievement::JumperIII => "JumperIII",
-            Achievement::JumperIV => "JumperIV",
-            Achievement::JumperV => "JumperV",
-            Achievement::TangoI => "TangoI",
-            Achievement::TangoII => "TangoII",
-            Achievement::TangoIII => "TangoIII",
-            Achievement::TangoIV => "TangoIV",
-            Achievement::TangoV => "TangoV",
+            Achievement::MiniGamer => 'MiniGamer',
+            Achievement::MasterGamer => 'MasterGamer',
+            Achievement::LegendGamer => 'LegendGamer',
+            Achievement::AllStarGamer => 'AllStarGamer',
+            Achievement::ScoreHunterI => 'ScoreHunterI',
+            Achievement::ScoreHunterII => 'ScoreHunterII',
+            Achievement::ScoreHunterIII => 'ScoreHunterIII',
+            Achievement::ScoreHunterIV => 'ScoreHunterIV',
+            Achievement::ScoreHunterV => 'ScoreHunterV',
+            Achievement::JumperI => 'JumperI',
+            Achievement::JumperII => 'JumperII',
+            Achievement::JumperIII => 'JumperIII',
+            Achievement::JumperIV => 'JumperIV',
+            Achievement::JumperV => 'JumperV',
+            Achievement::TangoI => 'TangoI',
+            Achievement::TangoII => 'TangoII',
+            Achievement::TangoIII => 'TangoIII',
+            Achievement::TangoIV => 'TangoIV',
+            Achievement::TangoV => 'TangoV',
         }
     }
 
@@ -78,7 +84,6 @@ impl AchievementImpl of AchievementTrait {
             Achievement::TangoV => false,
         }
     }
-    
 
     #[inline]
     fn index(self: Achievement) -> u8 {
@@ -337,7 +342,7 @@ impl AchievementImpl of AchievementTrait {
     }
 }
 
-impl IntoAchievementU8 of core::Into<Achievement, u8> {
+pub impl IntoAchievementU8 of Into<Achievement, u8> {
     #[inline]
     fn into(self: Achievement) -> u8 {
         match self {
@@ -369,7 +374,7 @@ impl IntoAchievementU8 of core::Into<Achievement, u8> {
     }
 }
 
-impl IntoU8Achievement of core::Into<u8, Achievement> {
+pub impl IntoU8Achievement of Into<u8, Achievement> {
     #[inline]
     fn into(self: u8) -> Achievement {
         let value: felt252 = self.into();

--- a/dojo/src/constants.cairo
+++ b/dojo/src/constants.cairo
@@ -31,6 +31,25 @@ pub const XL_UPDATE_POINTS: u8 = 10;
 
 // Achievements
 pub const ACHIEVEMENTS_COUNT: u8 = 19;
+pub const MINIGAMES_ACHIEVEMENTS_COUNT: u8 = 4;
+// ScoreHunter
+pub const SCOREHUNTERI_POINTS: u32 = 2000;
+pub const SCOREHUNTERII_POINTS: u32 = 5000;
+pub const SCOREHUNTERIII_POINTS: u32 = 12000;
+pub const SCOREHUNTERIV_POINTS: u32 = 20000;
+pub const SCOREHUNTERV_POINTS: u32 = 50000;
+// Jumper
+pub const JUMPERI_POINTS: u32 = 500;
+pub const JUMPERII_POINTS: u32 = 1500;
+pub const JUMPERIII_POINTS: u32 = 2500;
+pub const JUMPERIV_POINTS: u32 = 3500;
+pub const JUMPERV_POINTS: u32 = 4500;
+// Tango
+pub const TANGOI_POINTS: u32 = 25;
+pub const TANGOII_POINTS: u32 = 50;
+pub const TANGOIII_POINTS: u32 = 100;
+pub const TANGOIV_POINTS: u32 = 200;
+pub const TANGOV_POINTS: u32 = 350;
 
 // Next level experience
 pub const NEXT_LEVEL_EXPERIENCE: u8 = 20;

--- a/dojo/src/constants.cairo
+++ b/dojo/src/constants.cairo
@@ -29,6 +29,9 @@ pub const M_UPDATE_POINTS: u8 = 6;
 pub const L_UPDATE_POINTS: u8 = 8;
 pub const XL_UPDATE_POINTS: u8 = 10;
 
+// Achievements
+pub const ACHIEVEMENTS_COUNT: u8 = 19;
+
 // Next level experience
 pub const NEXT_LEVEL_EXPERIENCE: u8 = 20;
 

--- a/dojo/src/lib.cairo
+++ b/dojo/src/lib.cairo
@@ -13,6 +13,7 @@ pub mod helpers {
 pub mod systems {
     pub mod game;
     pub mod player;
+    pub mod achieve;
 }
 
 pub mod models {

--- a/dojo/src/lib.cairo
+++ b/dojo/src/lib.cairo
@@ -1,6 +1,10 @@
 pub mod constants;
 pub mod store;
 
+pub mod achievements{
+    pub mod achievement;
+}
+
 pub mod helpers {
     pub mod timestamp;
     pub mod pseudo_random;

--- a/dojo/src/systems/achieve.cairo
+++ b/dojo/src/systems/achieve.cairo
@@ -1,0 +1,219 @@
+// Interface definition
+#[starknet::interface]
+pub trait IAchieve<T> {
+    // ------------------------- Minigames achievement methods -------------------------
+    fn achieve_play_minigame(ref self: T);
+    fn achieve_player_new_total_points(ref self: T);
+    fn achieve_platform_highscore(ref self: T, score: u32);
+    fn achieve_flappy_beast_highscore(ref self: T, score: u32);
+}
+
+#[dojo::contract]
+pub mod achieve {
+    // Local import
+    use super::{IAchieve};
+
+    // Constants import
+    use tamagotchi::constants;
+
+    // Starknet imports
+    use starknet::{get_block_timestamp};
+
+    // Tamagotchi achievements import
+    use tamagotchi::achievements::achievement::{Achievement, AchievementTrait};
+
+    // Dojo achievements imports
+    use achievement::components::achievable::AchievableComponent;
+    use achievement::store::{StoreTrait as AchievementStoreTrait};
+    component!(path: AchievableComponent, storage: achievable, event: AchievableEvent);
+    impl AchievableInternalImpl = AchievableComponent::InternalImpl<ContractState>;
+
+    // Model imports
+    #[allow(unused_imports)]
+    use tamagotchi::models::beast::{Beast, BeastTrait};
+    use tamagotchi::models::player::{Player, PlayerAssert};
+
+    // Store import
+    use tamagotchi::store::{StoreTrait};
+
+    // Dojo Imports
+    #[allow(unused_imports)]
+    use dojo::model::{ModelStorage};
+    #[allow(unused_imports)]
+    use dojo::event::EventStorage;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        achievable: AchievableComponent::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        AchievableEvent: AchievableComponent::Event,
+    }
+
+    // Constructor
+    fn dojo_init(ref self: ContractState) {
+        // [Event] Emit all Achievement creation events
+        let mut world = self.world(@"tamagotchi");
+
+        let mut achievement_id: u8 = 1;
+        while achievement_id <= constants::ACHIEVEMENTS_COUNT {
+            let achievement: Achievement = achievement_id.into();
+            self
+                .achievable
+                .create(
+                    world,
+                    id: achievement.identifier(),
+                    hidden: achievement.hidden(),
+                    index: achievement.index(),
+                    points: achievement.points(),
+                    start: achievement.start(),
+                    end: achievement.end(),
+                    group: achievement.group(),
+                    icon: achievement.icon(),
+                    title: achievement.title(),
+                    description: achievement.description(),
+                    tasks: achievement.tasks(),
+                    data: achievement.data(),
+                );
+            achievement_id += 1;
+        }
+    }
+
+    // Implementation of the interface methods
+    #[abi(embed_v0)]
+    impl AchieveImpl of IAchieve<ContractState> {
+        // ------------------------- Minigames achievement methods -------------------------
+        // Minigames
+        fn achieve_play_minigame(ref self: ContractState){
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+            let achievement_store = AchievementStoreTrait::new(world);
+
+            let mut player: Player = store.read_player();
+            player.assert_exists();
+
+            // Emit all minigames progress
+            let mut achievement_id: u8 = 1;
+            
+            while achievement_id <= constants::MINIGAMES_ACHIEVEMENTS_COUNT {
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+                achievement_id += 1;
+            }
+        }
+
+        // Score hunter
+        fn achieve_player_new_total_points(ref self: ContractState){
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+            let achievement_store = AchievementStoreTrait::new(world);
+
+            let mut player: Player = store.read_player();
+            player.assert_exists();
+
+            let player_points = player.total_points;
+            
+            if player_points >= constants::SCOREHUNTERI_POINTS && player_points <= constants::SCOREHUNTERII_POINTS {
+                // ScoreHunterI
+                let achievement_id: felt252 = 'ScoreHunterI';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if player_points >= constants::SCOREHUNTERII_POINTS &&  player_points <= constants::SCOREHUNTERIII_POINTS {
+                // ScoreHunterII
+                let achievement_id: felt252 = 'ScoreHunterII';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if player_points >= constants::SCOREHUNTERIII_POINTS && player_points <= constants::SCOREHUNTERIV_POINTS {
+                // ScoreHunterII
+                let achievement_id: felt252 = 'ScoreHunterIII';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if player_points >= constants::SCOREHUNTERIV_POINTS && player_points <= constants::SCOREHUNTERV_POINTS {
+                // ScoreHunterII
+                let achievement_id: felt252 = 'ScoreHunterIV';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if player_points >= constants::SCOREHUNTERV_POINTS {
+                // ScoreHunterII
+                let achievement_id: felt252 = 'ScoreHunterV';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+        }
+
+        // Platform minigame
+        fn achieve_platform_highscore(ref self: ContractState, score: u32){
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+            let achievement_store = AchievementStoreTrait::new(world);
+
+            let mut player: Player = store.read_player();
+            player.assert_exists();
+
+            if score >= constants::JUMPERI_POINTS && score <= constants::JUMPERII_POINTS {
+                // JumperI
+                let achievement_id: felt252 = 'JumperI';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if score >= constants::JUMPERII_POINTS && score <= constants::JUMPERIII_POINTS {
+                // JumperII
+                let achievement_id: felt252 = 'JumperII';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if score >= constants::JUMPERIII_POINTS && score <= constants::JUMPERIV_POINTS {
+                // JumperIII
+                let achievement_id: felt252 = 'JumperIII';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if score >= constants::JUMPERIV_POINTS && score <= constants::JUMPERV_POINTS{
+                // JumperIV
+                let achievement_id: felt252 = 'JumperIV';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if score >= constants::JUMPERV_POINTS {
+                // JumperV
+                let achievement_id: felt252 = 'JumperV';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+        }
+
+        // Flappy beasts minigame
+        fn achieve_flappy_beast_highscore(ref self: ContractState, score: u32){
+            let mut world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+            let achievement_store = AchievementStoreTrait::new(world);
+
+            let mut player: Player = store.read_player();
+            player.assert_exists();
+
+            if score >= constants::TANGOI_POINTS && score <= constants::JUMPERII_POINTS {
+                // TangoI
+                let achievement_id: felt252 = 'TangoI';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if score >= constants::TANGOI_POINTS && score <= constants::JUMPERIII_POINTS {
+                // TangoII
+                let achievement_id: felt252 = 'TangoII';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if score >= constants::TANGOI_POINTS && score <= constants::JUMPERIV_POINTS {
+                // TangoIII
+                let achievement_id: felt252 = 'TangoIII';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if score >= constants::TANGOI_POINTS && score <= constants::JUMPERV_POINTS{
+                // TangoIV
+                let achievement_id: felt252 = 'TangoIV';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+            if score >= constants::TANGOI_POINTS {
+                // TangoV
+                let achievement_id: felt252 = 'TangoV';
+                achievement_store.progress(player.address.into(), achievement_id.into(), 1, get_block_timestamp());
+            }
+        }
+    }
+}

--- a/dojo/src/systems/player.cairo
+++ b/dojo/src/systems/player.cairo
@@ -16,12 +16,17 @@ pub mod player {
     // Local import
     use super::{IPlayer};
 
+    // Constants import
+    use tamagotchi::constants;
+
     // Starknet imports
     use starknet::{get_block_timestamp, ContractAddress};
 
-    // Achievements imports
+    // Tamagotchi achievements import
+    use tamagotchi::achievements::achievement::{Achievement, AchievementTrait};
+
+    // Dojo achievements imports
     use achievement::components::achievable::AchievableComponent;
-    use achievement::types::task::{Task, TaskTrait}; 
     use achievement::store::{StoreTrait as AchievementStoreTrait};
     component!(path: AchievableComponent, storage: achievable, event: AchievableEvent);
     impl AchievableInternalImpl = AchievableComponent::InternalImpl<ContractState>;
@@ -62,27 +67,29 @@ pub mod player {
     fn dojo_init(ref self: ContractState) {
         // [Event] Emit all Achievement creation events
         let mut world = self.world(@"tamagotchi");
-        let task_id = '1';
-        let task_target = 1; // The amount of times needed to complete a task
-        let task = TaskTrait::new(task_id, task_target, "Reach 10 pts in the minigame 1 time");
-        let tasks: Span<Task> = array![task].span();
 
-        // Create the achievement
-        let achievement_store = AchievementStoreTrait::new(world);
-        achievement_store.create(
-            id: '1',
-            hidden: false,
-            index: 0,
-            points: 10, // This set the total points to reach in order to complete the achievement
-            start: 0,
-            end: 0,
-            group: 'Minigame',
-            icon: 'fa-trophy',
-            title: 'Beginner of the minigame',
-            description: "Has reached 10 pts in the minigame",
-            tasks: tasks,
-            data: "",
-        );
+        let mut achievement_id: u8 = 1;
+            while achievement_id <= constants::ACHIEVEMENTS_COUNT {
+                let achievement: Achievement = achievement_id.into();
+                self
+                    .achievable
+                    .create(
+                        world,
+                        id: achievement.identifier(),
+                        hidden: achievement.hidden(),
+                        index: achievement.index(),
+                        points: achievement.points(),
+                        start: achievement.start(),
+                        end: achievement.end(),
+                        group: achievement.group(),
+                        icon: achievement.icon(),
+                        title: achievement.title(),
+                        description: achievement.description(),
+                        tasks: achievement.tasks(),
+                        data: achievement.data(),
+                    );
+                achievement_id += 1;
+            }
     }
 
     // Implementation of the interface methods

--- a/dojo/src/systems/player.cairo
+++ b/dojo/src/systems/player.cairo
@@ -16,21 +16,9 @@ pub mod player {
     // Local import
     use super::{IPlayer};
 
-    // Constants import
-    use tamagotchi::constants;
-
     // Starknet imports
     use starknet::{get_block_timestamp, ContractAddress};
-
-    // Tamagotchi achievements import
-    use tamagotchi::achievements::achievement::{Achievement, AchievementTrait};
-
-    // Dojo achievements imports
-    use achievement::components::achievable::AchievableComponent;
-    use achievement::store::{StoreTrait as AchievementStoreTrait};
-    component!(path: AchievableComponent, storage: achievable, event: AchievableEvent);
-    impl AchievableInternalImpl = AchievableComponent::InternalImpl<ContractState>;
-
+    
     // Model imports
     #[allow(unused_imports)]
     use tamagotchi::models::beast::{Beast, BeastTrait};
@@ -50,47 +38,8 @@ pub mod player {
     #[allow(unused_imports)]
     use dojo::event::EventStorage;
 
-    #[storage]
-    struct Storage {
-        #[substorage(v0)]
-        achievable: AchievableComponent::Storage,
-    }
-
-    #[event]
-    #[derive(Drop, starknet::Event)]
-    enum Event {
-        #[flat]
-        AchievableEvent: AchievableComponent::Event,
-    }
-
     // Constructor
-    fn dojo_init(ref self: ContractState) {
-        // [Event] Emit all Achievement creation events
-        let mut world = self.world(@"tamagotchi");
-
-        let mut achievement_id: u8 = 1;
-            while achievement_id <= constants::ACHIEVEMENTS_COUNT {
-                let achievement: Achievement = achievement_id.into();
-                self
-                    .achievable
-                    .create(
-                        world,
-                        id: achievement.identifier(),
-                        hidden: achievement.hidden(),
-                        index: achievement.index(),
-                        points: achievement.points(),
-                        start: achievement.start(),
-                        end: achievement.end(),
-                        group: achievement.group(),
-                        icon: achievement.icon(),
-                        title: achievement.title(),
-                        description: achievement.description(),
-                        tasks: achievement.tasks(),
-                        data: achievement.data(),
-                    );
-                achievement_id += 1;
-            }
-    }
+    fn dojo_init(ref self: ContractState) {}
 
     // Implementation of the interface methods
     #[abi(embed_v0)]
@@ -138,19 +87,9 @@ pub mod player {
             player.update_total_points(points);
 
             store.write_player(@player);
-
-            // Emit progress event when the player earns points in the minigame
-            let task_id = '1'; // Should be the same as the one in dojo_init
-            let count = 1; // This is the times a task is completed in order to complete the achievement
-            let achievement_store = AchievementStoreTrait::new(world); // Achievement store
-            let time = starknet::get_block_timestamp(); // Current timestamp
-
-            achievement_store.progress(player.address.into(), task_id, count, time); 
         }
 
-        fn update_player_minigame_highest_score(
-            ref self: ContractState, points: u32, minigame_id: u16,
-        ) {
+        fn update_player_minigame_highest_score(ref self: ContractState, points: u32, minigame_id: u16) {
             let mut world = self.world(@"tamagotchi");
             let store = StoreTrait::new(world);
 


### PR DESCRIPTION
## Summary

Closes #363

This PR introduces the **first official implementation of the Achievements system** for the MiniGames group. It defines and integrates a wide range of achievements that reward player progression based on gameplay milestones.

### Included Achievements

```rust
Achievement::None => 0,
Achievement::MiniGamer => 'MiniGamer',         // Play a minigame once
Achievement::MasterGamer => 'MasterGamer',     // Play a minigame 15 times
Achievement::LegendGamer => 'LegendGamer',     // Play a minigame 30 times
Achievement::AllStarGamer => 'AllStarGamer',   // Play a minigame 50 times

Achievement::ScoreHunterI => 'ScoreHunterI',   // Get 2000 total points from minigames
Achievement::ScoreHunterII => 'ScoreHunterII', // Get 5000 total points from minigames
Achievement::ScoreHunterIII => 'ScoreHunterIII', // Get 12000 total points from minigames
Achievement::ScoreHunterIV => 'ScoreHunterIV', // Get 20000 total points from minigames
Achievement::ScoreHunterV => 'ScoreHunterV',   // Get 50000 total points from minigames

Achievement::JumperI => 'JumperI',             // Reach 500 points in a single platform game
Achievement::JumperII => 'JumperII',           // Reach 1500 points in a single platform game
Achievement::JumperIII => 'JumperIII',         // Reach 2500 points in a single platform game
Achievement::JumperIV => 'JumperIV',           // Reach 3500 points in a single platform game
Achievement::JumperV => 'JumperV',             // Reach 4500 points in a single platform game

Achievement::TangoI => 'TangoI',               // Reach 25 points in a single flappy beasts game
Achievement::TangoII => 'TangoII',             // Reach 50 points in a single flappy beasts game
Achievement::TangoIII => 'TangoIII',           // Reach 100 points in a single flappy beasts game
Achievement::TangoIV => 'TangoIV',             // Reach 200 points in a single flappy beasts game
Achievement::TangoV => 'TangoV',               // Reach 350 points in a single flappy beasts game
```

### Implementation Details

* Introduced a new `achievements` module that defines the `Achievement` enum and associated helper methods via trait implementation.
* Created a dedicated **Achievements System Contract** to serve as the entry point for managing achievement-related actions and validations.

  * This design keeps the game and player contracts focused on their own responsibilities.
  * Core logic is encapsulated in a single location, improving readability, maintainability, and modularity.

## Next Steps
* Integrate calls to the new achievement system from the client during key gameplay actions to track and emit player progress.
* Test and validate integration through the controller to ensure proper functionality.

