### PR TITLE
[FEAT]: Refactor social achieve methods

### DIFF
--- a/dojo/manifest_sepolia.json
+++ b/dojo/manifest_sepolia.json
@@ -1313,7 +1313,7 @@
   "contracts": [
     {
       "address": "0x1005116a48c9a8f7a6c946091e64dc8ced37962dc2bbb74355868229307c20d",
-      "class_hash": "0x5a4c23fa69d235e89b7607a1b8ba8aadae993cd7cd9adaa8e94310f3c7b100f",
+      "class_hash": "0x5a0717d24dae3e31ca2e15fd1f06cf26d9de52b84e56500d1179e38647c056e",
       "abi": [
         {
           "type": "impl",
@@ -1449,7 +1449,14 @@
             },
             {
               "type": "function",
-              "name": "achieve_social_share",
+              "name": "achieve_beast_share",
+              "inputs": [],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "achieve_score_share",
               "inputs": [
                 {
                   "name": "score",
@@ -1600,7 +1607,8 @@
         "achieve_beast_pet",
         "achieve_beast_sleep",
         "achieve_beast_clean",
-        "achieve_social_share",
+        "achieve_beast_share",
+        "achieve_score_share",
         "achieve_beast_chat",
         "upgrade"
       ]

--- a/dojo/src/systems/achieve.cairo
+++ b/dojo/src/systems/achieve.cairo
@@ -12,7 +12,8 @@ pub trait IAchieve<T> {
     fn achieve_beast_sleep(ref self: T);
     fn achieve_beast_clean(ref self: T);
     // ------------------------- Social achievement methods -------------------------
-    fn achieve_social_share(ref self: T, score: u32);
+    fn achieve_beast_share(ref self: T);
+    fn achieve_score_share(ref self: T, score: u32);
     fn achieve_beast_chat(ref self: T);
 }
 
@@ -314,8 +315,8 @@ pub mod achieve {
         }
 
         // ------------------------- Social achievement methods -------------------------
-        // Share on social media
-        fn achieve_social_share(ref self: ContractState, score: u32) {
+         // Share beast on social media
+        fn achieve_beast_share(ref self: ContractState) {
             let world = self.world(@"tamagotchi");
             let store = StoreTrait::new(world);
             let achievement_store = AchievementStoreTrait::new(world);
@@ -334,7 +335,17 @@ pub mod achieve {
                 achievement_store.progress(player.address.into(), task_identifier, 1, get_block_timestamp());
                 achievement_id += 1;
             };
+        }
+
+        // Share score on social media 
+        fn achieve_score_share(ref self: ContractState, score: u32) {
+            let world = self.world(@"tamagotchi");
+            let store = StoreTrait::new(world);
+            let achievement_store = AchievementStoreTrait::new(world);
         
+            let player = store.read_player();
+            player.assert_exists();
+            
             // Progress ArenaRockstar (score thresholds)
             if score >= constants::ARENAROCKSTARI_POINTS && score <= constants::ARENAROCKSTARII_POINTS {
                 let task_id: felt252 = 'ArenaRockstarI';


### PR DESCRIPTION
## Summary

* Refactored the `achieve_social` logic by splitting it into two separate methods within the `achieve` contract for improved modularity and readability.
* Updated the manifest file to reflect the addition of these new methods.

## Notes

* Deployment was performed using the same seed to **preserve the existing contract address.**

